### PR TITLE
CD-726: Update Teams Device Status Script with Single Device Option

### DIFF
--- a/examples/http/teams_rooms_device_status.json
+++ b/examples/http/teams_rooms_device_status.json
@@ -1,49 +1,51 @@
 {
-    "logo": "ms-teams.svg",
-    "version": "1.0.1",
-    "name": "Microsoft Teams Rooms - Device status",
-    "description": "This script retrieves information about Room Devices, including detailed health status for each device",
-    "category": "Software Integration",
-    "requirements": {
-        "credentials": false,
-        "sandbox_version": "1.12",
-        "others": [
-            "Microsoft Teams",
-            "Grant permission to extract the list of room devices and  health details: TeamworkDevice.Read.All"
-        ]
-    },
-    "tags": [
-        "teams"
-    ],
-    "sample_period_s": 1800,
-    "has_actions": false,
-    "expected_variables": {
-        "table": "[24]"
-    },
-    "protocols": [
-        "HTTPS"
-    ],
-    "tested_on": [
-        {
-            "name": "Microsoft Graph API",
-            "version": "beta"
-        }
-    ],
-    "parameters": [
-        {
-            "value_type": "STRING",
-            "name": "tenantId",
-            "label": "Tenant Id"
-        },
-        {
-            "value_type": "STRING",
-            "name": "clientId",
-            "label": "Client Id"
-        },
-        {
-            "value_type": "SECRET_TEXT",
-            "name": "clientSecret",
-            "label": "Client Secret"
-        }
+  "logo": "ms-teams.svg",
+  "version": "1.0.2",
+  "name": "Microsoft Teams Rooms - Device status",
+  "description": "This script retrieves information about Room Devices, including detailed health status for each device",
+  "category": "Software Integration",
+  "requirements": {
+    "credentials": false,
+    "sandbox_version": "1.12",
+    "others": [
+      "Microsoft Teams",
+      "Grant permission to extract the list of room devices and  health details: TeamworkDevice.Read.All"
     ]
+  },
+  "tags": ["teams"],
+  "sample_period_s": 1800,
+  "has_actions": false,
+  "expected_variables": {
+    "table": "[24]"
+  },
+  "protocols": ["HTTPS"],
+  "tested_on": [
+    {
+      "name": "Microsoft Graph API",
+      "version": "beta"
+    }
+  ],
+  "parameters": [
+    {
+      "value_type": "STRING",
+      "name": "tenantId",
+      "label": "Tenant Id"
+    },
+    {
+      "value_type": "STRING",
+      "name": "clientId",
+      "label": "Client Id"
+    },
+    {
+      "value_type": "SECRET_TEXT",
+      "name": "clientSecret",
+      "label": "Client Secret"
+    },
+    {
+      "value_type": "STRING",
+      "name": "filterByDeviceSerialNumber",
+      "label": "Set to true to filter Tems device inventory by Domotz device serial",
+      "value": "true"
+    }
+  ]
 }

--- a/examples/http/teams_rooms_device_status.json
+++ b/examples/http/teams_rooms_device_status.json
@@ -44,7 +44,7 @@
     {
       "value_type": "STRING",
       "name": "filterByDeviceSerialNumber",
-      "label": "Set to true to filter Tems device inventory by Domotz device serial",
+      "label": "Set to true to filter Teams device inventory by Domotz device serial",
       "value": "true"
     }
   ]


### PR DESCRIPTION
Hi there, here is the version that shows only the device whose serial number matches the Domotz device the script is attached to, and when there is a single device it displays the result as key value instead of a table, I also updated the JSON file and set the value to true, please check this part because I am not sure if it is correct, I have seen in other scripts that this is the way to pass a default value to parameters, thanks and let me know, Riccardo