### PR TITLE
NEC-1583: update WinRM examples — fix timeoutSec, expose transport op…

### DIFF
--- a/examples/winrm/failed_login.js
+++ b/examples/winrm/failed_login.js
@@ -50,8 +50,7 @@ const config = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,            // per-command timeout in milliseconds
 };
 
 const failedLogonTable = D.createTable(

--- a/examples/winrm/failed_login.js
+++ b/examples/winrm/failed_login.js
@@ -45,7 +45,13 @@ const command = '$Hours=' + hours + ';$events=Get-WinEvent -FilterHashTable @{Lo
 const config = {
     "username": D.device.username(),
     "password": D.device.password(),
-    "timeout": 30000
+    // WinRM transport options:
+    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
+    scheme: "http",            // "http" | "https"
+    skipVerify: true,          // when scheme="https", skip TLS cert verification
+    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
+    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
 };
 
 const failedLogonTable = D.createTable(

--- a/examples/winrm/failed_login.json
+++ b/examples/winrm/failed_login.json
@@ -1,6 +1,6 @@
 {
     "logo": "windows.svg",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "name": "Windows Failed Logon attempts",
     "description": "monitors the failed logon on a Windows computer.",
     "category": "Software Integration",

--- a/examples/winrm/hyperv_monitoring_vm_snapshot.js
+++ b/examples/winrm/hyperv_monitoring_vm_snapshot.js
@@ -30,7 +30,13 @@ var vmNameFilter = D.getParameter("vmName");
 // WinRM configuration
 var winrmConfig = {
     "username": D.device.username(),
-    "password": D.device.password()
+    "password": D.device.password(),
+    // WinRM transport options:
+    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
+    scheme: "http",            // "http" | "https"
+    skipVerify: true,          // when scheme="https", skip TLS cert verification
+    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
 };
 
 // Table to store VM snapshots

--- a/examples/winrm/hyperv_monitoring_vm_snapshot.js
+++ b/examples/winrm/hyperv_monitoring_vm_snapshot.js
@@ -36,7 +36,7 @@ var winrmConfig = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,               // per-command timeout in milliseconds
 };
 
 // Table to store VM snapshots

--- a/examples/winrm/hyperv_monitoring_vm_snapshot.json
+++ b/examples/winrm/hyperv_monitoring_vm_snapshot.json
@@ -1,6 +1,6 @@
 {
     "logo": "microsoft-hyper-v.svg",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "name": "Hyper-V VM Snapshot",
     "description": "This script retrieves information about the latest snapshots taken on Hyper-V virtual machines. It allows monitoring of snapshot creation time and age",
     "category": "Software Integration",
@@ -51,7 +51,9 @@
             "value_type": "LIST",
             "name": "vmName",
             "label": "VM Name",
-            "value": ["All"]
+            "value": [
+                "All"
+            ]
         }
     ]
 }

--- a/examples/winrm/ms_exchange_current_connections.js
+++ b/examples/winrm/ms_exchange_current_connections.js
@@ -23,7 +23,13 @@ var counters = "\\Web Service(*)\\Current Connections";
 var winrmConfig = {
     "command": 'Get-Counter -Counter "' + counters + '" | ForEach-Object { $_.countersamples | Select-Object path, InstanceName, CookedValue } | ConvertTo-Json',
     "username": D.device.username(),
-    "password": D.device.password()
+    "password": D.device.password(),
+    // WinRM transport options:
+    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
+    scheme: "http",            // "http" | "https"
+    skipVerify: true,          // when scheme="https", skip TLS cert verification
+    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
 };
 
 // Check for Errors on the WinRM command response

--- a/examples/winrm/ms_exchange_current_connections.js
+++ b/examples/winrm/ms_exchange_current_connections.js
@@ -29,7 +29,7 @@ var winrmConfig = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,               // per-command timeout in milliseconds
 };
 
 // Check for Errors on the WinRM command response

--- a/examples/winrm/ms_exchange_current_connections.json
+++ b/examples/winrm/ms_exchange_current_connections.json
@@ -1,13 +1,13 @@
 {
     "logo": "ms-exchange.svg",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "Microsoft Exchange Server (on-prem) - Current Connections",
     "description": "This script is used to monitor the number of current connections to a Microsoft Exchange Server",
     "category": "Software Integration",
     "requirements": {
         "credentials": true,
         "sandbox_version": "1.12",
-        "others": [ 
+        "others": [
             "Powershell Version 5.1.19041.2364",
             "WinRM Enabled"
         ]

--- a/examples/winrm/ms_exchange_database_stats.js
+++ b/examples/winrm/ms_exchange_database_stats.js
@@ -34,7 +34,7 @@ var winrmConfig = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,               // per-command timeout in milliseconds
 };
 
 var table = D.createTable(

--- a/examples/winrm/ms_exchange_database_stats.js
+++ b/examples/winrm/ms_exchange_database_stats.js
@@ -28,7 +28,13 @@ var counters = [
 var winrmConfig = {
     "command": 'Get-Counter -Counter ' + counters.map(function(counter){return '"' + counter + '"';}).join(',') + ' | ForEach-Object { $_.countersamples | Select-Object path, InstanceName, CookedValue } | ConvertTo-Json',
     "username": D.device.username(),
-    "password": D.device.password()
+    "password": D.device.password(),
+    // WinRM transport options:
+    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
+    scheme: "http",            // "http" | "https"
+    skipVerify: true,          // when scheme="https", skip TLS cert verification
+    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
 };
 
 var table = D.createTable(

--- a/examples/winrm/ms_exchange_database_stats.json
+++ b/examples/winrm/ms_exchange_database_stats.json
@@ -1,13 +1,13 @@
 {
     "logo": "ms-exchange.svg",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "Microsoft Exchange Server (on-prem) - Database Latency (R/W)",
     "description": "This script is used to monitor database statistics from a Microsoft Exchange Server",
     "category": "Software Integration",
     "requirements": {
         "credentials": true,
         "sandbox_version": "1.12",
-        "others": [ 
+        "others": [
             "Powershell Version 5.1.19041.2364",
             "WinRM Enabled"
         ]

--- a/examples/winrm/ms_exchange_fault_rate.js
+++ b/examples/winrm/ms_exchange_fault_rate.js
@@ -34,7 +34,7 @@ var winrmConfig = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,               // per-command timeout in milliseconds
 };
 
 var table = D.createTable(

--- a/examples/winrm/ms_exchange_fault_rate.js
+++ b/examples/winrm/ms_exchange_fault_rate.js
@@ -28,7 +28,13 @@ var counters = [
 var winrmConfig = {
     "command": 'Get-Counter -Counter ' + counters.map(function(counter){return '"' + counter + '"';}).join(',') + ' | ForEach-Object { $_.countersamples | Select-Object path, InstanceName, CookedValue } | ConvertTo-Json',
     "username": D.device.username(),
-    "password": D.device.password()
+    "password": D.device.password(),
+    // WinRM transport options:
+    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
+    scheme: "http",            // "http" | "https"
+    skipVerify: true,          // when scheme="https", skip TLS cert verification
+    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
 };
 
 var table = D.createTable(

--- a/examples/winrm/ms_exchange_fault_rate.json
+++ b/examples/winrm/ms_exchange_fault_rate.json
@@ -1,13 +1,13 @@
 {
     "logo": "ms-exchange.svg",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "Microsoft Exchange Server (on-prem) - Fault Rate",
     "description": "This script is used to monitor database fault rates from a Microsoft Exchange Server",
     "category": "Software Integration",
     "requirements": {
         "credentials": true,
         "sandbox_version": "1.12",
-        "others": [ 
+        "others": [
             "Powershell Version 5.1.19041.2364",
             "WinRM Enabled"
         ]

--- a/examples/winrm/ms_exchange_general_stats.js
+++ b/examples/winrm/ms_exchange_general_stats.js
@@ -63,7 +63,13 @@ var counterTypeMappings = {
 var winrmConfig = {
     "command": 'Get-Counter -Counter ' + counters.map(function(counter){return '"' + counter + '"';}).join(',') + ' | ForEach-Object { $_.countersamples | Select-Object path, InstanceName, CookedValue, CounterType  } | ConvertTo-Json',
     "username": D.device.username(),
-    "password": D.device.password()
+    "password": D.device.password(),
+    // WinRM transport options:
+    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
+    scheme: "http",            // "http" | "https"
+    skipVerify: true,          // when scheme="https", skip TLS cert verification
+    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
 };
 
 // Check for Errors on the WinRM command response

--- a/examples/winrm/ms_exchange_general_stats.js
+++ b/examples/winrm/ms_exchange_general_stats.js
@@ -69,7 +69,7 @@ var winrmConfig = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,               // per-command timeout in milliseconds
 };
 
 // Check for Errors on the WinRM command response

--- a/examples/winrm/ms_exchange_general_stats.json
+++ b/examples/winrm/ms_exchange_general_stats.json
@@ -1,13 +1,13 @@
 {
     "logo": "ms-exchange.svg",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "Microsoft Exchange Server (on-prem) - General Stats",
     "description": "This script is used to monitor various general statistics on a Microsoft Exchange Server",
     "category": "Software Integration",
     "requirements": {
         "credentials": true,
         "sandbox_version": "1.12",
-        "others": [ 
+        "others": [
             "Powershell Version 5.1.19041.2364",
             "WinRM Enabled"
         ]

--- a/examples/winrm/ms_exchange_ldap.js
+++ b/examples/winrm/ms_exchange_ldap.js
@@ -34,7 +34,7 @@ var winrmConfig = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,               // per-command timeout in milliseconds
 };
 
 var table = D.createTable(

--- a/examples/winrm/ms_exchange_ldap.js
+++ b/examples/winrm/ms_exchange_ldap.js
@@ -28,7 +28,13 @@ var counters = [
 var winrmConfig = {
     "command": 'Get-Counter -Counter ' + counters.map(function(counter){return '"' + counter + '"';}).join(',') + ' | ForEach-Object { $_.countersamples | Select-Object path, InstanceName, CookedValue } | ConvertTo-Json',
     "username": D.device.username(),
-    "password": D.device.password()
+    "password": D.device.password(),
+    // WinRM transport options:
+    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
+    scheme: "http",            // "http" | "https"
+    skipVerify: true,          // when scheme="https", skip TLS cert verification
+    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
 };
 
 var table = D.createTable(

--- a/examples/winrm/ms_exchange_ldap.json
+++ b/examples/winrm/ms_exchange_ldap.json
@@ -1,13 +1,13 @@
 {
     "logo": "ms-exchange.svg",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "Microsoft Exchange Server (on-prem) - LDAP Read/Search Time",
     "description": "This script is used to monitor LDAP (Lightweight Directory Access Protocol) read and search times on a Microsoft Exchange Server",
     "category": "Software Integration",
     "requirements": {
         "credentials": true,
         "sandbox_version": "1.12",
-        "others": [ 
+        "others": [
             "Powershell Version 5.1.19041.2364",
             "WinRM Enabled"
         ]

--- a/examples/winrm/ms_exchange_queues.js
+++ b/examples/winrm/ms_exchange_queues.js
@@ -28,7 +28,7 @@ var winrmConfig = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,               // per-command timeout in milliseconds
 };
 
 // Check for Errors on the WinRM command response

--- a/examples/winrm/ms_exchange_queues.js
+++ b/examples/winrm/ms_exchange_queues.js
@@ -22,7 +22,13 @@ var counters = "\\MSExchangeTransport Queues(*)\\Messages Queued For Delivery";
 var winrmConfig = {
     "command": 'Get-Counter -Counter "' + counters + '" | ForEach-Object { $_.countersamples | Select-Object path, InstanceName, CookedValue } | ConvertTo-Json',
     "username": D.device.username(),
-    "password": D.device.password()
+    "password": D.device.password(),
+    // WinRM transport options:
+    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
+    scheme: "http",            // "http" | "https"
+    skipVerify: true,          // when scheme="https", skip TLS cert verification
+    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
 };
 
 // Check for Errors on the WinRM command response

--- a/examples/winrm/ms_exchange_queues.json
+++ b/examples/winrm/ms_exchange_queues.json
@@ -1,13 +1,13 @@
 {
     "logo": "ms-exchange.svg",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "Microsoft Exchange Server (on-prem) - Messages Queued for Delivery",
     "description": "This script is used to monitor the messages queued for delivery on-prem Microsoft Exchange Server",
     "category": "Software Integration",
     "requirements": {
         "credentials": true,
         "sandbox_version": "1.12",
-        "others": [ 
+        "others": [
             "Powershell Version 5.1.19041.2364",
             "WinRM Enabled"
         ]

--- a/examples/winrm/ms_exchange_rpc_average_latency.js
+++ b/examples/winrm/ms_exchange_rpc_average_latency.js
@@ -23,7 +23,13 @@ var counters = "\\MSExchangeIS Store(*)\\RPC Average Latency";
 var winrmConfig = {
     "command": 'Get-Counter -Counter "' + counters + '" | ForEach-Object { $_.countersamples | Select-Object path, InstanceName, CookedValue } | ConvertTo-Json',
     "username": D.device.username(),
-    "password": D.device.password()
+    "password": D.device.password(),
+    // WinRM transport options:
+    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
+    scheme: "http",            // "http" | "https"
+    skipVerify: true,          // when scheme="https", skip TLS cert verification
+    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
 };
 
 // Check for Errors on the WinRM command response

--- a/examples/winrm/ms_exchange_rpc_average_latency.js
+++ b/examples/winrm/ms_exchange_rpc_average_latency.js
@@ -29,7 +29,7 @@ var winrmConfig = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,               // per-command timeout in milliseconds
 };
 
 // Check for Errors on the WinRM command response

--- a/examples/winrm/ms_exchange_rpc_average_latency.json
+++ b/examples/winrm/ms_exchange_rpc_average_latency.json
@@ -1,13 +1,13 @@
 {
     "logo": "ms-exchange.svg",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "Microsoft Exchange Server - RPC (Remote Procedure Call) Average Latency",
     "description": "This script is used to monitor the RPC (Remote Procedure Call) Average Latency on a Microsoft Exchange Server",
     "category": "Software Integration",
     "requirements": {
         "credentials": true,
         "sandbox_version": "1.12",
-        "others": [ 
+        "others": [
             "Powershell Version 5.1.19041.2364",
             "WinRM Enabled"
         ]

--- a/examples/winrm/sql_server.js
+++ b/examples/winrm/sql_server.js
@@ -47,7 +47,7 @@ var winrmConfig = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,               // per-command timeout in milliseconds
 };
 
 // Function to handle WinRM errors

--- a/examples/winrm/sql_server.js
+++ b/examples/winrm/sql_server.js
@@ -41,7 +41,13 @@ var sqlQuery = 'Invoke-Sqlcmd -Query "SELECT GETDATE() AS TimeOfQuery" -ServerIn
 // Define the WinRM options when running the commands
 var winrmConfig = {
     "username": username,
-    "password": password
+    "password": password,
+    // WinRM transport options:
+    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
+    scheme: "http",            // "http" | "https"
+    skipVerify: true,          // when scheme="https", skip TLS cert verification
+    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
 };
 
 // Function to handle WinRM errors

--- a/examples/winrm/sql_server.json
+++ b/examples/winrm/sql_server.json
@@ -1,6 +1,6 @@
 {
     "logo": "",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "SQLServer Status Monitoring",
     "description": "Monitor the status of a SQL Server database to check if it is able to serve requests",
     "category": "Software Integration",

--- a/examples/winrm/veeam_backup_sessions_monitoring.js
+++ b/examples/winrm/veeam_backup_sessions_monitoring.js
@@ -92,7 +92,13 @@ function generateVeeamCmd() {
 const config = {
     "username": veeamServerUsername,
     "password": veeamServerPassword,
-    "timeout": 60000
+    // WinRM transport options:
+    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
+    scheme: "http",            // "http" | "https"
+    skipVerify: true,          // when scheme="https", skip TLS cert verification
+    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    timeout: 60000,             // SSH per-command timeout (ms); ignored by WinRM
+    timeoutSec: 60,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
 };
 
 const veeamTable = D.createTable(

--- a/examples/winrm/veeam_backup_sessions_monitoring.js
+++ b/examples/winrm/veeam_backup_sessions_monitoring.js
@@ -97,8 +97,7 @@ const config = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeout: 60000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 60,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 60000,            // per-command timeout in milliseconds
 };
 
 const veeamTable = D.createTable(

--- a/examples/winrm/veeam_backup_sessions_monitoring.json
+++ b/examples/winrm/veeam_backup_sessions_monitoring.json
@@ -1,75 +1,78 @@
 {
-  "logo": "veeam.svg",
-  "version": "1.0.0",
-  "name": "Veeam Backup Sessions Monitoring (External Device)",
-  "description": "Experimental script - This script provides the status of replication job or the last n replication jobs of a single VM replicated by Veeam",
-  "category": "Software Integration",
-  "requirements": {
-    "credentials": false,
-    "sandbox_version": "1.12",
-    "others": [
-      "PowerShell Version 5.1.20348.3932",
-      "Privilege required: Local Administrator privileges",
-      "WinRM Enabled (if using WinRM protocol)",
-      "SSH Enabled (if using SSH protocol)",
-      "Veeam Backup & Replication PowerShell module installed"
+    "logo": "veeam.svg",
+    "version": "1.0.1",
+    "name": "Veeam Backup Sessions Monitoring (External Device)",
+    "description": "Experimental script - This script provides the status of replication job or the last n replication jobs of a single VM replicated by Veeam",
+    "category": "Software Integration",
+    "requirements": {
+        "credentials": false,
+        "sandbox_version": "1.12",
+        "others": [
+            "PowerShell Version 5.1.20348.3932",
+            "Privilege required: Local Administrator privileges",
+            "WinRM Enabled (if using WinRM protocol)",
+            "SSH Enabled (if using SSH protocol)",
+            "Veeam Backup & Replication PowerShell module installed"
+        ]
+    },
+    "tags": [
+        "experimental",
+        "windows",
+        "software",
+        "veeam",
+        "backup",
+        "monitoring",
+        "external-device"
+    ],
+    "sample_period_s": 600,
+    "has_actions": false,
+    "expected_variables": {
+        "table": "[7]"
+    },
+    "protocols": [
+        "WINRM",
+        "SSH"
+    ],
+    "tested_on": [
+        {
+            "name": "Windows Server",
+            "version": "2022"
+        },
+        {
+            "name": "Veeam Backup & Replication",
+            "version": "12 v12.3.2.3617 CE"
+        }
+    ],
+    "parameters": [
+        {
+            "value_type": "STRING",
+            "name": "vmName",
+            "label": "VM name"
+        },
+        {
+            "value_type": "STRING",
+            "name": "numberOfResults",
+            "label": "Number of results"
+        },
+        {
+            "value_type": "STRING",
+            "name": "protocol",
+            "label": "Protocol (WINRM or SSH)"
+        },
+        {
+            "value_type": "STRING",
+            "name": "veeamServerIP",
+            "label": "Veeam server IP"
+        },
+        {
+            "value_type": "STRING",
+            "name": "veeamServerUsername",
+            "label": "Veeam server username"
+        },
+        {
+            "value_type": "SECRET_TEXT",
+            "name": "veeamServerPassword",
+            "label": "Veeam server password"
+        }
     ]
-  },
-  "tags": [
-    "experimental",
-    "windows",
-    "software",
-    "veeam",
-    "backup",
-    "monitoring",
-    "external-device"
-  ],
-  "sample_period_s": 600,
-  "has_actions": false,
-  "expected_variables": {
-    "table": "[7]"
-  },
-  "protocols": ["WINRM", "SSH"],
-  "tested_on": [
-    {
-      "name": "Windows Server",
-      "version": "2022"
-    },
-    {
-      "name": "Veeam Backup & Replication",
-      "version": "12 v12.3.2.3617 CE"
-    }
-  ],
-  "parameters": [
-    {
-      "value_type": "STRING",
-      "name": "vmName",
-      "label": "VM name"
-    },
-    {
-      "value_type": "STRING",
-      "name": "numberOfResults",
-      "label": "Number of results"
-    },
-    {
-      "value_type": "STRING",
-      "name": "protocol",
-      "label": "Protocol (WINRM or SSH)"
-    },
-    {
-      "value_type": "STRING",
-      "name": "veeamServerIP",
-      "label": "Veeam server IP"
-    },
-    {
-      "value_type": "STRING",
-      "name": "veeamServerUsername",
-      "label": "Veeam server username"
-    },
-    {
-      "value_type": "SECRET_TEXT",
-      "name": "veeamServerPassword",
-      "label": "Veeam server password"
-    }
-  ]
 }

--- a/examples/winrm/windows_audit_settings.js
+++ b/examples/winrm/windows_audit_settings.js
@@ -115,7 +115,13 @@ const instance = protocol.toLowerCase() === "ssh" ? new SSHHandler() : new WinRM
 const config = {
     username: D.device.username(),
     password: D.device.password(),
-    timeout: 30000
+    // WinRM transport options:
+    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
+    scheme: "http",            // "http" | "https"
+    skipVerify: true,          // when scheme="https", skip TLS cert verification
+    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
+    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
 };
 
 let filter = [

--- a/examples/winrm/windows_audit_settings.js
+++ b/examples/winrm/windows_audit_settings.js
@@ -120,8 +120,7 @@ const config = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,            // per-command timeout in milliseconds
 };
 
 let filter = [

--- a/examples/winrm/windows_audit_settings.json
+++ b/examples/winrm/windows_audit_settings.json
@@ -1,6 +1,6 @@
 {
     "logo": "windows.svg",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "name": "Windows Audit Settings",
     "description": "Monitor the audit settings on Windows",
     "category": "Software Integration",

--- a/examples/winrm/windows_cpu_memory.js
+++ b/examples/winrm/windows_cpu_memory.js
@@ -60,8 +60,7 @@ const config = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,            // per-command timeout in milliseconds
 };
 
 function parseValidateOutput(isValidated) {

--- a/examples/winrm/windows_cpu_memory.json
+++ b/examples/winrm/windows_cpu_memory.json
@@ -1,6 +1,6 @@
 {
     "logo": "windows.svg",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "name": "Windows CPU and Memory",
     "description": "Monitors CPU and memory usage of a Windows machine",
     "category": "Software Integration",

--- a/examples/winrm/windows_cpu_memory_https.js
+++ b/examples/winrm/windows_cpu_memory_https.js
@@ -62,8 +62,7 @@ const config = {
     scheme: "https",           // "http" | "https"
     skipVerify: true,          // set to false to enforce TLS certificate verification
     // auth: "auto",           // "basic" | "ntlm" | "auto" (inferred from username)
-    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds
+    timeout: 30000,            // per-command timeout in milliseconds
 };
 
 function parseValidateOutput(isValidated) {

--- a/examples/winrm/windows_cpu_memory_https.js
+++ b/examples/winrm/windows_cpu_memory_https.js
@@ -1,7 +1,9 @@
 /**
  * Domotz Custom Driver
- * Name: Windows CPU and Memory
+ * Name: Windows CPU and Memory (HTTPS)
  * Description: Monitors CPU and memory usage of a Windows machine.
+ * Uses WinRM over HTTPS (port 5986). Requires the WinRM listener configured for HTTPS on the target.
+ *
  * Please note that to retrieve CPU load metric it is necessary to add the WinRM user to the security group "Performance Monitor Users"
  *
  * Communication protocol are:
@@ -55,13 +57,13 @@ const command = '@{ TotalMemory = ' + totalMemory + '; AvailableMemory = ' + ava
 const config = {
     "username": D.device.username(),
     "password": D.device.password(),
-    // WinRM transport options:
-    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
-    scheme: "http",            // "http" | "https"
-    skipVerify: true,          // when scheme="https", skip TLS cert verification
-    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    // WinRM transport options for HTTPS (port 5986). Adjust as needed:
+    port: 5986,                // 5986 = HTTPS (5985 for HTTP)
+    scheme: "https",           // "http" | "https"
+    skipVerify: true,          // set to false to enforce TLS certificate verification
+    // auth: "auto",           // "basic" | "ntlm" | "auto" (inferred from username)
     timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeoutSec: 30,            // per-command timeout in seconds
 };
 
 function parseValidateOutput(isValidated) {

--- a/examples/winrm/windows_cpu_memory_https.json
+++ b/examples/winrm/windows_cpu_memory_https.json
@@ -1,0 +1,47 @@
+{
+    "logo": "windows.svg",
+    "version": "1.1.2",
+    "name": "Windows CPU and Memory (HTTPS)",
+    "description": "Monitors CPU and memory usage of a Windows machine (over WinRM HTTPS on port 5986).",
+    "category": "Software Integration",
+    "requirements": {
+        "credentials": true,
+        "sandbox_version": "1.12",
+        "others": [
+            "Powershell Version 5.1.21996.1",
+            "Privilege required: Administrator",
+            "WinRM Enabled: To run the script using WinRM",
+            "SSH Enabled: To run the script using SSH",
+            "WinRM HTTPS listener enabled on the target (default port 5986)"
+        ]
+    },
+    "tags": [
+        "windows",
+        "cpu",
+        "memory",
+        "status"
+    ],
+    "sample_period_s": 900,
+    "has_actions": false,
+    "expected_variables": {
+        "independent": "[9]"
+    },
+    "protocols": [
+        "WINRM",
+        "SSH"
+    ],
+    "tested_on": [
+        {
+            "name": "Windows",
+            "version": "11"
+        }
+    ],
+    "parameters": [
+        {
+            "value_type": "STRING",
+            "name": "protocol",
+            "label": "Protocol",
+            "value": "WINRM"
+        }
+    ]
+}

--- a/examples/winrm/windows_cpu_usage.js
+++ b/examples/winrm/windows_cpu_usage.js
@@ -38,8 +38,7 @@ const config = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,            // per-command timeout in milliseconds
 };
 
 function parseValidateOutput(isValidated) {

--- a/examples/winrm/windows_cpu_usage.js
+++ b/examples/winrm/windows_cpu_usage.js
@@ -33,7 +33,13 @@ const command = "Get-WmiObject Win32_Processor | Measure-Object -Property LoadPe
 const config = {
     "username": D.device.username(),
     "password": D.device.password(),
-    "timeout": 30000
+    // WinRM transport options:
+    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
+    scheme: "http",            // "http" | "https"
+    skipVerify: true,          // when scheme="https", skip TLS cert verification
+    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
+    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
 };
 
 function parseValidateOutput(isValidated) {

--- a/examples/winrm/windows_cpu_usage.json
+++ b/examples/winrm/windows_cpu_usage.json
@@ -1,6 +1,6 @@
 {
     "logo": "windows.svg",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "name": "Windows CPU Usage",
     "description": "Monitor the average CPU load average percentage of a Windows server.",
     "category": "Software Integration",

--- a/examples/winrm/windows_cpu_usage_https.js
+++ b/examples/winrm/windows_cpu_usage_https.js
@@ -40,8 +40,7 @@ const config = {
     scheme: "https",           // "http" | "https"
     skipVerify: true,          // set to false to enforce TLS certificate verification
     // auth: "auto",           // "basic" | "ntlm" | "auto" (inferred from username)
-    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds
+    timeout: 30000,            // per-command timeout in milliseconds
 };
 
 function parseValidateOutput(isValidated) {

--- a/examples/winrm/windows_cpu_usage_https.js
+++ b/examples/winrm/windows_cpu_usage_https.js
@@ -1,14 +1,15 @@
 /**
  * Domotz Custom Driver
- * Name: Windows Host Users Monitoring
- * Description: Monitors the status of all the existing users on a Windows machine
+ * Name: Windows CPU usage (HTTPS)
+ * Description: This driver retrieves the average CPU load average percentage of a Windows server.
+ * Uses WinRM over HTTPS (port 5986). Requires the WinRM listener configured for HTTPS on the target.
+ *
  *
  * Communication protocol are:
  *      - WinRM
  *      - SSH
  *
  * The communication protocol can be chosen as either SSH or WinRM by specifying it through the "protocol" parameter.
- *
  *
  * Tested on Windows Versions:
  *      - Windows 10
@@ -20,47 +21,28 @@
  *    - WinRM Enabled: To run the script using WinRM
  *    - SSH Enabled: To run the script using SSH
  *
+ * Creates a Custom Driver Variable with CPU load average percentage
  *
- * Creates a Custom Driver Table with the following columns:
- *  - Name
- *  - Status
- *  - Description
- *
- **/
+ */
 
 // Specify the communication protocol to be used (SSH or WinRM)
 const protocol = D.getParameter('protocol');
 
 const instance = protocol.toLowerCase() === "ssh" ? new SSHHandler() : new WinRMHandler();
 
-// Define the WinRM options when running the commands
+const command = "Get-WmiObject Win32_Processor | Measure-Object -Property LoadPercentage -Average | Select Average"
+
 const config = {
     "username": D.device.username(),
     "password": D.device.password(),
-    // WinRM transport options:
-    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
-    scheme: "http",            // "http" | "https"
-    skipVerify: true,          // when scheme="https", skip TLS cert verification
-    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    // WinRM transport options for HTTPS (port 5986). Adjust as needed:
+    port: 5986,                // 5986 = HTTPS (5985 for HTTP)
+    scheme: "https",           // "http" | "https"
+    skipVerify: true,          // set to false to enforce TLS certificate verification
+    // auth: "auto",           // "basic" | "ntlm" | "auto" (inferred from username)
     timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeoutSec: 30,            // per-command timeout in seconds
 };
-
-const hostUsersTable = D.createTable(
-    "Host Users",
-    [
-        {label: "Name"},
-        {label: "Status"},
-        {label: "Description"}
-    ]
-);
-const userDetailsRegexp = /([\w\d]+)\s+([\w]+)\s+(.*)/;
-
-/**
- * @remote_procedure
- * @label Validate WinRM is working on device
- * @documentation This procedure is used to validate if the driver can be applied on a device during association as well as validate any credentials provided
- */
 
 function parseValidateOutput(isValidated) {
     if (isValidated) {
@@ -72,8 +54,12 @@ function parseValidateOutput(isValidated) {
     }
 }
 
+/**
+ * @remote_procedure
+ * @label Validate WinRM connectivity with the device
+ * @documentation This procedure is used to validate the driver and credentials provided during association.
+ */
 function validate() {
-    const command = "Test-WSMan";
     instance.executeCommand(command)
         .then(instance.checkIfValidated)
         .then(parseValidateOutput)
@@ -82,38 +68,29 @@ function validate() {
 
 /**
  * @remote_procedure
- * @label Get Host Device Users
- * @documentation This procedure retrieves the users on the host device and outputs if they are enabled or not
+ * @label Get CPU usage percentage
+ * @documentation This procedure retrieves the average CPU load percentage of the device.
  */
 function get_status() {
-    instance.executeCommand("Get-LocalUser")
+    instance.executeCommand(command)
         .then(instance.parseOutputToArray)
         .then(parseOutput)
         .catch(instance.checkError);
 }
 
-
-function parseOutput(outputLines) {
-    if (outputLines.length >= 2 ){
-        for (let i = 2; i < outputLines.length; i++) {
-            const line = outputLines[i];
-            if (line !== "") {
-                const match = line.match(userDetailsRegexp);
-                if (match) {
-                    const name = match[1];
-                    const recordId = name.toLowerCase().substring(0, 50);
-                    const status = match[2];
-                    const description = match[3];
-                    hostUsersTable.insertRecord(recordId, [name, status, description]);
-                }
-            }
-        }
-    }
-    D.success(hostUsersTable);
+/**
+ * Parses the output of the WinRM command and extracts the CPU load percentage.
+ * @param {object} output - The output of the WinRM command.
+ */
+function parseOutput(output) {
+    const cpuValue = output[2].replace(/\s+/g, ""); // To remove all spaces
+    const cpuLoadAverage = D.device.createVariable("cpu-load-average", "CPU Load Average", cpuValue, "%", D.valueType.NUMBER);
+    D.success([cpuLoadAverage]);
 }
 
 // WinRM functions
-function WinRMHandler() {}
+function WinRMHandler() {
+}
 
 // Check for Errors on the command response
 WinRMHandler.prototype.checkError = function (output) {

--- a/examples/winrm/windows_cpu_usage_https.json
+++ b/examples/winrm/windows_cpu_usage_https.json
@@ -1,0 +1,49 @@
+{
+    "logo": "windows.svg",
+    "version": "1.1.1",
+    "name": "Windows CPU Usage (HTTPS)",
+    "description": "Monitor the average CPU load average percentage of a Windows server (over WinRM HTTPS on port 5986).",
+    "category": "Software Integration",
+    "requirements": {
+        "credentials": true,
+        "sandbox_version": "1.12",
+        "others": [
+            "Powershell Version 5.1.19041.2364",
+            "WinRM Enabled: To run the script using WinRM",
+            "SSH Enabled: To run the script using SSH",
+            "WinRM HTTPS listener enabled on the target (default port 5986)"
+        ]
+    },
+    "tags": [
+        "windows",
+        "software",
+        "cpu"
+    ],
+    "sample_period_s": 300,
+    "has_actions": false,
+    "expected_variables": {
+        "independent": "[1]"
+    },
+    "protocols": [
+        "WINRM",
+        "SSH"
+    ],
+    "tested_on": [
+        {
+            "name": "Microsoft Windows",
+            "version": "Server 2019"
+        },
+        {
+            "name": "Microsoft Windows",
+            "version": "10"
+        }
+    ],
+    "parameters": [
+        {
+            "value_type": "STRING",
+            "name": "protocol",
+            "label": "Protocol",
+            "value": "WINRM"
+        }
+    ]
+}

--- a/examples/winrm/windows_current_sessions.js
+++ b/examples/winrm/windows_current_sessions.js
@@ -45,7 +45,13 @@ const command = 'Start-Process quser -NoNewWindow -RedirectStandardError "NUL"'
 const config = {
     "username": D.device.username(),
     "password": D.device.password(),
-    "timeout": 30000
+    // WinRM transport options:
+    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
+    scheme: "http",            // "http" | "https"
+    skipVerify: true,          // when scheme="https", skip TLS cert verification
+    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
+    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
 };
 const usersTable = D.createTable(
     "Logged In Users",

--- a/examples/winrm/windows_current_sessions.js
+++ b/examples/winrm/windows_current_sessions.js
@@ -50,8 +50,7 @@ const config = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,            // per-command timeout in milliseconds
 };
 const usersTable = D.createTable(
     "Logged In Users",

--- a/examples/winrm/windows_current_sessions.json
+++ b/examples/winrm/windows_current_sessions.json
@@ -1,6 +1,6 @@
 {
     "logo": "windows.svg",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "name": "Windows Sessions",
     "description": "Monitor the list of current logged in users",
     "category": "Software Integration",

--- a/examples/winrm/windows_firewall_rules.js
+++ b/examples/winrm/windows_firewall_rules.js
@@ -57,8 +57,7 @@ const config = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,            // per-command timeout in milliseconds
 };
 
 const directionCodes = {

--- a/examples/winrm/windows_firewall_rules.js
+++ b/examples/winrm/windows_firewall_rules.js
@@ -52,7 +52,13 @@ if (firewallFilter.length === 1 && firewallFilter[0].toLowerCase() === 'all') {
 const config = {
     "username": D.device.username(),
     "password": D.device.password(),
-    "timeout": 30000
+    // WinRM transport options:
+    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
+    scheme: "http",            // "http" | "https"
+    skipVerify: true,          // when scheme="https", skip TLS cert verification
+    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
+    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
 };
 
 const directionCodes = {

--- a/examples/winrm/windows_firewall_rules.json
+++ b/examples/winrm/windows_firewall_rules.json
@@ -1,6 +1,6 @@
 {
     "logo": "windows.svg",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "name": "Windows Firewall Rules",
     "description": "Show Firewall Rules on a Windows machine",
     "category": "Software Integration",
@@ -39,7 +39,10 @@
             "value_type": "LIST",
             "name": "firewallFilter",
             "label": "Firewall Rule Name",
-            "value": ["skype", "AnyDesk"]
+            "value": [
+                "skype",
+                "AnyDesk"
+            ]
         },
         {
             "value_type": "STRING",

--- a/examples/winrm/windows_gpo_version.js
+++ b/examples/winrm/windows_gpo_version.js
@@ -32,7 +32,7 @@ var winrmConfig = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,               // per-command timeout in milliseconds
 };
 
 /**

--- a/examples/winrm/windows_gpo_version.js
+++ b/examples/winrm/windows_gpo_version.js
@@ -26,7 +26,13 @@
 var winrmConfig = {
     "command": "",
     "username": D.device.username(),
-    "password": D.device.password()
+    "password": D.device.password(),
+    // WinRM transport options:
+    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
+    scheme: "http",            // "http" | "https"
+    skipVerify: true,          // when scheme="https", skip TLS cert verification
+    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
 };
 
 /**

--- a/examples/winrm/windows_gpo_version.json
+++ b/examples/winrm/windows_gpo_version.json
@@ -1,6 +1,6 @@
 {
     "logo": "windows.svg",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "Windows AD GPOs versions",
     "description": "Monitor the versions of selected GPOs. You can set the initial value as baseeline and get alerted if it changes",
     "category": "Software Integration",

--- a/examples/winrm/windows_host_users.js
+++ b/examples/winrm/windows_host_users.js
@@ -42,8 +42,7 @@ const config = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,            // per-command timeout in milliseconds
 };
 
 const hostUsersTable = D.createTable(

--- a/examples/winrm/windows_host_users.json
+++ b/examples/winrm/windows_host_users.json
@@ -1,6 +1,6 @@
 {
     "logo": "windows.svg",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "name": "Windows Host Users",
     "description": "Monitor the status of all the existing users on a Windows machine",
     "category": "Software Integration",

--- a/examples/winrm/windows_hyperv_VM_virtual_hard_drive.js
+++ b/examples/winrm/windows_hyperv_VM_virtual_hard_drive.js
@@ -42,7 +42,7 @@ const winrmConfig = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,               // per-command timeout in milliseconds
 }
 
 // mapping boolean values to human-readable strings.

--- a/examples/winrm/windows_hyperv_VM_virtual_hard_drive.js
+++ b/examples/winrm/windows_hyperv_VM_virtual_hard_drive.js
@@ -36,7 +36,13 @@ const getVmVirtualHardDrives = '(Get-VM -Id "' + vmIdFilter + '" | Select-Object
 const winrmConfig = {
   command: getVmVirtualHardDrives,
   username: D.device.username(),
-  password: D.device.password()
+  password: D.device.password(),
+    // WinRM transport options:
+    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
+    scheme: "http",            // "http" | "https"
+    skipVerify: true,          // when scheme="https", skip TLS cert verification
+    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
 }
 
 // mapping boolean values to human-readable strings.

--- a/examples/winrm/windows_hyperv_VM_virtual_hard_drive.json
+++ b/examples/winrm/windows_hyperv_VM_virtual_hard_drive.json
@@ -1,6 +1,6 @@
 {
     "logo": "microsoft-hyper-v.svg",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "name": "Windows Hyper-V VM Virtual Hard Drives",
     "description": "This script retrieves information about the Hyper-V VM Virtual Hard Drives",
     "category": "Software Integration",

--- a/examples/winrm/windows_hyperv_VM_virtual_network_adapters.js
+++ b/examples/winrm/windows_hyperv_VM_virtual_network_adapters.js
@@ -41,7 +41,7 @@ const winrmConfig = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,               // per-command timeout in milliseconds
 }
 
 const booleanCodes = {

--- a/examples/winrm/windows_hyperv_VM_virtual_network_adapters.js
+++ b/examples/winrm/windows_hyperv_VM_virtual_network_adapters.js
@@ -35,7 +35,13 @@ const getVmVirtualNetworkAdapters = '(Get-VM -id "' + vmIdFilter + '" | Select-O
 const winrmConfig = {
   command: getVmVirtualNetworkAdapters,
   username: D.device.username(),
-  password: D.device.password()
+  password: D.device.password(),
+    // WinRM transport options:
+    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
+    scheme: "http",            // "http" | "https"
+    skipVerify: true,          // when scheme="https", skip TLS cert verification
+    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
 }
 
 const booleanCodes = {

--- a/examples/winrm/windows_hyperv_VM_virtual_network_adapters.json
+++ b/examples/winrm/windows_hyperv_VM_virtual_network_adapters.json
@@ -1,6 +1,6 @@
 {
     "logo": "microsoft-hyper-v.svg",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "name": "Windows Hyper-V VM Virtual Network Adapters",
     "description": "This script retrieves information about the Hyper-V VM Virtual Network Adapters",
     "category": "Software Integration",

--- a/examples/winrm/windows_hyperv_monitor.js
+++ b/examples/winrm/windows_hyperv_monitor.js
@@ -40,7 +40,13 @@ const cmd = '(Get-VM | ForEach-Object ' +
 const winrmConfig = {
   command: cmd,
   username: D.device.username(),
-  password: D.device.password()
+  password: D.device.password(),
+    // WinRM transport options:
+    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
+    scheme: "http",            // "http" | "https"
+    skipVerify: true,          // when scheme="https", skip TLS cert verification
+    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
 }
 
 /**

--- a/examples/winrm/windows_hyperv_monitor.js
+++ b/examples/winrm/windows_hyperv_monitor.js
@@ -46,7 +46,7 @@ const winrmConfig = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,               // per-command timeout in milliseconds
 }
 
 /**

--- a/examples/winrm/windows_hyperv_monitor.json
+++ b/examples/winrm/windows_hyperv_monitor.json
@@ -1,6 +1,6 @@
 {
     "logo": "microsoft-hyper-v.svg",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "Windows Hyper-V Show all VMs",
     "description": "This script retrieves information about the Hyper-V Virtual machines",
     "category": "Software Integration",

--- a/examples/winrm/windows_hyperv_vm_integration_services.js
+++ b/examples/winrm/windows_hyperv_vm_integration_services.js
@@ -29,7 +29,13 @@ const getVmIntegrationServices = 'Get-VMIntegrationService -vm (get-vm -id "' + 
 const winrmConfig = {
   command: getVmIntegrationServices,
   username: D.device.username(),
-  password: D.device.password()
+  password: D.device.password(),
+    // WinRM transport options:
+    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
+    scheme: "http",            // "http" | "https"
+    skipVerify: true,          // when scheme="https", skip TLS cert verification
+    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
 }
 
 const booleanCodes = {

--- a/examples/winrm/windows_hyperv_vm_integration_services.js
+++ b/examples/winrm/windows_hyperv_vm_integration_services.js
@@ -35,7 +35,7 @@ const winrmConfig = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,               // per-command timeout in milliseconds
 }
 
 const booleanCodes = {

--- a/examples/winrm/windows_hyperv_vm_integration_services.json
+++ b/examples/winrm/windows_hyperv_vm_integration_services.json
@@ -1,6 +1,6 @@
 {
     "logo": "microsoft-hyper-v.svg",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "name": "Windows Hyper-V VM Integration Services",
     "description": "This script retrieves information about the Hyper-V VM Integration Services",
     "category": "Software Integration",

--- a/examples/winrm/windows_iplatency.js
+++ b/examples/winrm/windows_iplatency.js
@@ -34,7 +34,13 @@ const ipAddressesToCheck = D.getParameter('ipAddressesToCheck');
 const config = {
     username: D.device.username(),
     password: D.device.password(),
-    timeout: 30000
+    // WinRM transport options:
+    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
+    scheme: "http",            // "http" | "https"
+    skipVerify: true,          // when scheme="https", skip TLS cert verification
+    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
+    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
 };
 
 const tableColumns = D.createTable(

--- a/examples/winrm/windows_iplatency.js
+++ b/examples/winrm/windows_iplatency.js
@@ -39,8 +39,7 @@ const config = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,            // per-command timeout in milliseconds
 };
 
 const tableColumns = D.createTable(

--- a/examples/winrm/windows_logical_disks.js
+++ b/examples/winrm/windows_logical_disks.js
@@ -58,8 +58,7 @@ const config = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,            // per-command timeout in milliseconds
 }
 
 // Mapping of drive types

--- a/examples/winrm/windows_logical_disks.json
+++ b/examples/winrm/windows_logical_disks.json
@@ -1,6 +1,6 @@
 {
     "logo": "windows.svg",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "name": "Windows Logical Disks",
     "description": "Monitors the status of logical disks within a Windows machine",
     "category": "Software Integration",
@@ -10,7 +10,7 @@
         "others": [
             "Powershell Version 5.1.21996.1",
             "Privilege required: Administrator To retrieve BitLocker information and AD User to retrieve logical disks information",
-            "To get permissions: Access to the namespace 'Root\\Microsoft\\Windows\\Storage'. This can be achieved by executing the Domotz script", 
+            "To get permissions: Access to the namespace 'Root\\Microsoft\\Windows\\Storage'. This can be achieved by executing the Domotz script",
             "WinRM Enabled: To run the script using WinRM",
             "SSH Enabled: To run the script using SSH"
         ]

--- a/examples/winrm/windows_logical_disks_https.js
+++ b/examples/winrm/windows_logical_disks_https.js
@@ -60,8 +60,7 @@ const config = {
     scheme: "https",           // "http" | "https"
     skipVerify: true,          // set to false to enforce TLS certificate verification
     // auth: "auto",           // "basic" | "ntlm" | "auto" (inferred from username)
-    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds
+    timeout: 30000,            // per-command timeout in milliseconds
 }
 
 // Mapping of drive types

--- a/examples/winrm/windows_logical_disks_https.js
+++ b/examples/winrm/windows_logical_disks_https.js
@@ -1,7 +1,9 @@
 /**
  * Domotz Custom Driver
- * Name: Windows Logical Disks
+ * Name: Windows Logical Disks (HTTPS)
  * Description: Monitors the status of logical disks within a Windows machine.
+ * Uses WinRM over HTTPS (port 5986). Requires the WinRM listener configured for HTTPS on the target.
+ *
  *
  * Communication protocol are:
  *      - WinRM
@@ -53,13 +55,13 @@ const bitLockerCmd = 'Get-BitLockerVolume | Select-Object -Property MountPoint,V
 const config = {
     "username": D.device.username(),
     "password": D.device.password(),
-    // WinRM transport options:
-    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
-    scheme: "http",            // "http" | "https"
-    skipVerify: true,          // when scheme="https", skip TLS cert verification
-    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    // WinRM transport options for HTTPS (port 5986). Adjust as needed:
+    port: 5986,                // 5986 = HTTPS (5985 for HTTP)
+    scheme: "https",           // "http" | "https"
+    skipVerify: true,          // set to false to enforce TLS certificate verification
+    // auth: "auto",           // "basic" | "ntlm" | "auto" (inferred from username)
     timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeoutSec: 30,            // per-command timeout in seconds
 }
 
 // Mapping of drive types

--- a/examples/winrm/windows_logical_disks_https.json
+++ b/examples/winrm/windows_logical_disks_https.json
@@ -1,0 +1,48 @@
+{
+    "logo": "windows.svg",
+    "version": "1.1.2",
+    "name": "Windows Logical Disks (HTTPS)",
+    "description": "Monitors the status of logical disks within a Windows machine (over WinRM HTTPS on port 5986).",
+    "category": "Software Integration",
+    "requirements": {
+        "credentials": true,
+        "sandbox_version": "1.12",
+        "others": [
+            "Powershell Version 5.1.21996.1",
+            "Privilege required: Administrator To retrieve BitLocker information and AD User to retrieve logical disks information",
+            "To get permissions: Access to the namespace 'Root\\Microsoft\\Windows\\Storage'. This can be achieved by executing the Domotz script",
+            "WinRM Enabled: To run the script using WinRM",
+            "SSH Enabled: To run the script using SSH",
+            "WinRM HTTPS listener enabled on the target (default port 5986)"
+        ]
+    },
+    "tags": [
+        "windows",
+        "logical-disk",
+        "bitlocker",
+        "status"
+    ],
+    "sample_period_s": 300,
+    "has_actions": false,
+    "expected_variables": {
+        "table": "[13]"
+    },
+    "protocols": [
+        "WINRM",
+        "SSH"
+    ],
+    "tested_on": [
+        {
+            "name": "Windows",
+            "version": "11"
+        }
+    ],
+    "parameters": [
+        {
+            "value_type": "STRING",
+            "name": "protocol",
+            "label": "Protocol",
+            "value": "WINRM"
+        }
+    ]
+}

--- a/examples/winrm/windows_os_general_info.js
+++ b/examples/winrm/windows_os_general_info.js
@@ -53,8 +53,7 @@ const config = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,            // per-command timeout in milliseconds
 };
 
 function parseValidateOutput(isValidated) {

--- a/examples/winrm/windows_os_general_info.json
+++ b/examples/winrm/windows_os_general_info.json
@@ -1,6 +1,6 @@
 {
     "logo": "windows.svg",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "name": "Windows OS General Monitoring",
     "description": "Monitors the general information for Windows Operating System",
     "category": "Software Integration",

--- a/examples/winrm/windows_os_general_info_https.js
+++ b/examples/winrm/windows_os_general_info_https.js
@@ -55,8 +55,7 @@ const config = {
     scheme: "https",           // "http" | "https"
     skipVerify: true,          // set to false to enforce TLS certificate verification
     // auth: "auto",           // "basic" | "ntlm" | "auto" (inferred from username)
-    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds
+    timeout: 30000,            // per-command timeout in milliseconds
 };
 
 function parseValidateOutput(isValidated) {

--- a/examples/winrm/windows_os_general_info_https.js
+++ b/examples/winrm/windows_os_general_info_https.js
@@ -1,7 +1,9 @@
 /**
  * Domotz Custom Driver
- * Name: Windows OS General Monitoring
+ * Name: Windows OS General Monitoring (HTTPS)
  * Description: Monitors the general information for Windows Operating System
+ * Uses WinRM over HTTPS (port 5986). Requires the WinRM listener configured for HTTPS on the target.
+ *
  *
  * Communication protocol are:
  *      - WinRM
@@ -48,13 +50,13 @@ const instance = protocol.toLowerCase() === "ssh" ? new SSHHandler() : new WinRM
 const config = {
     "username": D.device.username(),
     "password": D.device.password(),
-    // WinRM transport options:
-    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
-    scheme: "http",            // "http" | "https"
-    skipVerify: true,          // when scheme="https", skip TLS cert verification
-    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    // WinRM transport options for HTTPS (port 5986). Adjust as needed:
+    port: 5986,                // 5986 = HTTPS (5985 for HTTP)
+    scheme: "https",           // "http" | "https"
+    skipVerify: true,          // set to false to enforce TLS certificate verification
+    // auth: "auto",           // "basic" | "ntlm" | "auto" (inferred from username)
     timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeoutSec: 30,            // per-command timeout in seconds
 };
 
 function parseValidateOutput(isValidated) {

--- a/examples/winrm/windows_os_general_info_https.json
+++ b/examples/winrm/windows_os_general_info_https.json
@@ -1,0 +1,53 @@
+{
+    "logo": "windows.svg",
+    "version": "1.1.2",
+    "name": "Windows OS General Monitoring (HTTPS)",
+    "description": "Monitors the general information for Windows Operating System (over WinRM HTTPS on port 5986).",
+    "category": "Software Integration",
+    "requirements": {
+        "credentials": true,
+        "sandbox_version": "1.12",
+        "others": [
+            "Powershell Version 5.1.21996.1",
+            "Privilege required: AD User",
+            "WinRM Enabled: To run the script using WinRM",
+            "SSH Enabled: To run the script using SSH",
+            "WinRM HTTPS listener enabled on the target (default port 5986)"
+        ]
+    },
+    "tags": [
+        "windows",
+        "operating-system",
+        "bios",
+        "name",
+        "version",
+        "build-number",
+        "architecture",
+        "serial-number",
+        "vendor",
+        "product-id"
+    ],
+    "sample_period_s": 86400,
+    "has_actions": false,
+    "expected_variables": {
+        "independent": "[7]"
+    },
+    "protocols": [
+        "WINRM",
+        "SSH"
+    ],
+    "tested_on": [
+        {
+            "name": "Windows",
+            "version": "11"
+        }
+    ],
+    "parameters": [
+        {
+            "value_type": "STRING",
+            "name": "protocol",
+            "label": "Protocol",
+            "value": "WINRM"
+        }
+    ]
+}

--- a/examples/winrm/windows_physical_disks.js
+++ b/examples/winrm/windows_physical_disks.js
@@ -47,8 +47,7 @@ const config = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,            // per-command timeout in milliseconds
 }
 
 // Custom Driver Table to store physical disk information

--- a/examples/winrm/windows_physical_disks.json
+++ b/examples/winrm/windows_physical_disks.json
@@ -1,6 +1,6 @@
 {
     "logo": "windows.svg",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "name": "Windows Physical Disks",
     "description": "Monitors the status of physical disks within a Windows machine",
     "category": "Software Integration",

--- a/examples/winrm/windows_physical_disks_https.js
+++ b/examples/winrm/windows_physical_disks_https.js
@@ -1,7 +1,9 @@
 /**
  * Domotz Custom Driver
- * Name: Windows Physical Disks
+ * Name: Windows Physical Disks (HTTPS)
  * Description: Monitors the status of physical disks within a Windows machine.
+ * Uses WinRM over HTTPS (port 5986). Requires the WinRM listener configured for HTTPS on the target.
+ *
  *
  * Communication protocol are:
  *      - WinRM
@@ -42,13 +44,13 @@ const command = 'Get-CimInstance Win32_DiskDrive | ForEach-Object { $partitions 
 const config = {
     username: D.device.username(),
     password: D.device.password(),
-    // WinRM transport options:
-    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
-    scheme: "http",            // "http" | "https"
-    skipVerify: true,          // when scheme="https", skip TLS cert verification
-    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    // WinRM transport options for HTTPS (port 5986). Adjust as needed:
+    port: 5986,                // 5986 = HTTPS (5985 for HTTP)
+    scheme: "https",           // "http" | "https"
+    skipVerify: true,          // set to false to enforce TLS certificate verification
+    // auth: "auto",           // "basic" | "ntlm" | "auto" (inferred from username)
     timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeoutSec: 30,            // per-command timeout in seconds
 }
 
 // Custom Driver Table to store physical disk information

--- a/examples/winrm/windows_physical_disks_https.js
+++ b/examples/winrm/windows_physical_disks_https.js
@@ -49,8 +49,7 @@ const config = {
     scheme: "https",           // "http" | "https"
     skipVerify: true,          // set to false to enforce TLS certificate verification
     // auth: "auto",           // "basic" | "ntlm" | "auto" (inferred from username)
-    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds
+    timeout: 30000,            // per-command timeout in milliseconds
 }
 
 // Custom Driver Table to store physical disk information

--- a/examples/winrm/windows_physical_disks_https.json
+++ b/examples/winrm/windows_physical_disks_https.json
@@ -1,0 +1,57 @@
+{
+    "logo": "windows.svg",
+    "version": "1.1.2",
+    "name": "Windows Physical Disks (HTTPS)",
+    "description": "Monitors the status of physical disks within a Windows machine (over WinRM HTTPS on port 5986).",
+    "category": "Software Integration",
+    "requirements": {
+        "credentials": true,
+        "sandbox_version": "1.12",
+        "others": [
+            "Powershell Version 5.1.21996.1",
+            "Privilege required: AD User",
+            "WinRM Enabled: To run the script using WinRM",
+            "SSH Enabled: To run the script using SSH",
+            "WinRM HTTPS listener enabled on the target (default port 5986)"
+        ]
+    },
+    "tags": [
+        "windows",
+        "physical-disk",
+        "model",
+        "status",
+        "size",
+        "free-space",
+        "usage",
+        "media-type",
+        "serial-number",
+        "partition"
+    ],
+    "sample_period_s": 300,
+    "has_actions": false,
+    "expected_variables": {
+        "table": "[8]"
+    },
+    "protocols": [
+        "WINRM",
+        "SSH"
+    ],
+    "tested_on": [
+        {
+            "name": "Windows",
+            "version": "10"
+        },
+        {
+            "name": "Windows",
+            "version": "11"
+        }
+    ],
+    "parameters": [
+        {
+            "value_type": "STRING",
+            "name": "protocol",
+            "label": "Protocol",
+            "value": "WINRM"
+        }
+    ]
+}

--- a/examples/winrm/windows_priviledged_users_count.js
+++ b/examples/winrm/windows_priviledged_users_count.js
@@ -25,7 +25,7 @@ var winrmConfig = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,               // per-command timeout in milliseconds
 };
 
 var privilegedUsersTable = D.createTable(

--- a/examples/winrm/windows_priviledged_users_count.js
+++ b/examples/winrm/windows_priviledged_users_count.js
@@ -19,7 +19,13 @@
 // Define winrm configuration
 var winrmConfig = {
     username: D.device.username(),
-    password: D.device.password()
+    password: D.device.password(),
+    // WinRM transport options:
+    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
+    scheme: "http",            // "http" | "https"
+    skipVerify: true,          // when scheme="https", skip TLS cert verification
+    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
 };
 
 var privilegedUsersTable = D.createTable(

--- a/examples/winrm/windows_priviledged_users_count.json
+++ b/examples/winrm/windows_priviledged_users_count.json
@@ -1,6 +1,6 @@
 {
     "logo": "windows.svg",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "Monitor the count of Windows Active Directory privileged users",
     "description": "Monitors the number of members of AD privileged groups",
     "category": "Software Integration",

--- a/examples/winrm/windows_security_events.js
+++ b/examples/winrm/windows_security_events.js
@@ -46,7 +46,13 @@ const instance = protocol.toLowerCase() === "ssh" ? new SSHHandler() : new WinRM
 const config = {
     username: D.device.username(),
     password: D.device.password(),
-    timeout: 30000
+    // WinRM transport options:
+    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
+    scheme: "http",            // "http" | "https"
+    skipVerify: true,          // when scheme="https", skip TLS cert verification
+    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
+    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
 };
 
 /**

--- a/examples/winrm/windows_security_events.js
+++ b/examples/winrm/windows_security_events.js
@@ -51,8 +51,7 @@ const config = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,            // per-command timeout in milliseconds
 };
 
 /**

--- a/examples/winrm/windows_security_events.json
+++ b/examples/winrm/windows_security_events.json
@@ -1,6 +1,6 @@
 {
     "logo": "windows.svg",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "name": "Windows Security events monitoring",
     "description": "Monitor the occurrences of Windows security events. Some events are only raised if the related audit setting is enabled. More info on https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/advanced-security-auditing-faq",
     "category": "Software Integration",

--- a/examples/winrm/windows_services.js
+++ b/examples/winrm/windows_services.js
@@ -55,8 +55,7 @@ const config = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,            // per-command timeout in milliseconds
 };
 
 const statusCodes = {

--- a/examples/winrm/windows_services.json
+++ b/examples/winrm/windows_services.json
@@ -1,6 +1,6 @@
 {
     "logo": "windows.svg",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "name": "Windows Services Monitoring",
     "description": "Monitor the status of chosen services on a Windows machine",
     "category": "Software Integration",
@@ -44,7 +44,15 @@
             "value_type": "LIST",
             "name": "servicesFilter",
             "label": "Service Name",
-            "value": ["dhcp", "dnscache", "LanmanServer", "MpsSvc", "RpcEptMapper", "schedule", "Windows Time"]
+            "value": [
+                "dhcp",
+                "dnscache",
+                "LanmanServer",
+                "MpsSvc",
+                "RpcEptMapper",
+                "schedule",
+                "Windows Time"
+            ]
         },
         {
             "value_type": "STRING",

--- a/examples/winrm/windows_services_https.js
+++ b/examples/winrm/windows_services_https.js
@@ -57,8 +57,7 @@ const config = {
     scheme: "https",           // "http" | "https"
     skipVerify: true,          // set to false to enforce TLS certificate verification
     // auth: "auto",           // "basic" | "ntlm" | "auto" (inferred from username)
-    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds
+    timeout: 30000,            // per-command timeout in milliseconds
 };
 
 const statusCodes = {

--- a/examples/winrm/windows_services_https.js
+++ b/examples/winrm/windows_services_https.js
@@ -1,7 +1,9 @@
 /**
  * Domotz Custom Driver
- * Name: Windows Services Monitoring
+ * Name: Windows Services Monitoring (HTTPS)
  * Description: Monitors the status of services on a Windows machine
+ * Uses WinRM over HTTPS (port 5986). Requires the WinRM listener configured for HTTPS on the target.
+ *
  *
  * Communication protocol are:
  *      - WinRM
@@ -50,13 +52,13 @@ function generateGetServicesCmd() {
 const config = {
     "username": D.device.username(),
     "password": D.device.password(),
-    // WinRM transport options:
-    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
-    scheme: "http",            // "http" | "https"
-    skipVerify: true,          // when scheme="https", skip TLS cert verification
-    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    // WinRM transport options for HTTPS (port 5986). Adjust as needed:
+    port: 5986,                // 5986 = HTTPS (5985 for HTTP)
+    scheme: "https",           // "http" | "https"
+    skipVerify: true,          // set to false to enforce TLS certificate verification
+    // auth: "auto",           // "basic" | "ntlm" | "auto" (inferred from username)
     timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeoutSec: 30,            // per-command timeout in seconds
 };
 
 const statusCodes = {

--- a/examples/winrm/windows_services_https.json
+++ b/examples/winrm/windows_services_https.json
@@ -1,0 +1,65 @@
+{
+    "logo": "windows.svg",
+    "version": "1.1.2",
+    "name": "Windows Services Monitoring (HTTPS)",
+    "description": "Monitor the status of chosen services on a Windows machine (over WinRM HTTPS on port 5986).",
+    "category": "Software Integration",
+    "requirements": {
+        "credentials": true,
+        "sandbox_version": "1.12",
+        "others": [
+            "Powershell Version 5.1.19041.2364",
+            "Privilege required: Local Administrator",
+            "WinRM Enabled: To run the script using WinRM",
+            "SSH Enabled: To run the script using SSH",
+            "WinRM HTTPS listener enabled on the target (default port 5986)"
+        ]
+    },
+    "tags": [
+        "windows",
+        "services",
+        "software"
+    ],
+    "sample_period_s": 3600,
+    "execution_time_s": 60,
+    "has_actions": false,
+    "expected_variables": {
+        "table": "[3]"
+    },
+    "protocols": [
+        "WINRM",
+        "SSH"
+    ],
+    "tested_on": [
+        {
+            "name": "Microsoft Windows",
+            "version": "Server 2019"
+        },
+        {
+            "name": "Microsoft Windows",
+            "version": "10"
+        }
+    ],
+    "parameters": [
+        {
+            "value_type": "LIST",
+            "name": "servicesFilter",
+            "label": "Service Name",
+            "value": [
+                "dhcp",
+                "dnscache",
+                "LanmanServer",
+                "MpsSvc",
+                "RpcEptMapper",
+                "schedule",
+                "Windows Time"
+            ]
+        },
+        {
+            "value_type": "STRING",
+            "name": "protocol",
+            "label": "Protocol",
+            "value": "WINRM"
+        }
+    ]
+}

--- a/examples/winrm/windows_static_ip_monitor.js
+++ b/examples/winrm/windows_static_ip_monitor.js
@@ -51,8 +51,7 @@ const config = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,            // per-command timeout in milliseconds
 }
 
 // mapping boolean values to human-readable strings.

--- a/examples/winrm/windows_static_ip_monitor.js
+++ b/examples/winrm/windows_static_ip_monitor.js
@@ -46,7 +46,13 @@ const instance = protocol.toLowerCase() === "ssh" ? new SSHHandler() : new WinRM
 const config = {
     username: D.device.username(),
     password: D.device.password(),
-    timeout: 30000
+    // WinRM transport options:
+    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
+    scheme: "http",            // "http" | "https"
+    skipVerify: true,          // when scheme="https", skip TLS cert verification
+    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
+    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
 }
 
 // mapping boolean values to human-readable strings.

--- a/examples/winrm/windows_static_ip_monitor.json
+++ b/examples/winrm/windows_static_ip_monitor.json
@@ -1,6 +1,6 @@
 {
     "logo": "windows.svg",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "name": "Windows Static IP Monitor",
     "description": "This script retrieves and monitors static IP information for network interfaces on Windows machines.",
     "category": "Software Integration",
@@ -44,7 +44,10 @@
             "value_type": "LIST",
             "name": "interfaceAliases",
             "label": "Network Interface Aliases",
-            "value": ["Ethernet", "Wi-Fi"]
+            "value": [
+                "Ethernet",
+                "Wi-Fi"
+            ]
         },
         {
             "value_type": "STRING",

--- a/examples/winrm/windows_updates.js
+++ b/examples/winrm/windows_updates.js
@@ -38,8 +38,7 @@ const config = {
     scheme: "http",            // "http" | "https"
     skipVerify: true,          // when scheme="https", skip TLS cert verification
     auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
-    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeout: 30000,            // per-command timeout in milliseconds
 };
 
 // Creation of custom driver table

--- a/examples/winrm/windows_updates.json
+++ b/examples/winrm/windows_updates.json
@@ -1,6 +1,6 @@
 {
     "logo": "windows.svg",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "name": "Windows Updates",
     "description": "Collect data on missing updates for a windows host",
     "category": "Software Integration",

--- a/examples/winrm/windows_updates_https.js
+++ b/examples/winrm/windows_updates_https.js
@@ -1,7 +1,9 @@
 /**
  * Domotz Custom Driver
- * Name: Windows Updates
+ * Name: Windows Updates (HTTPS)
  * Description: Reports on the missing updates
+ * Uses WinRM over HTTPS (port 5986). Requires the WinRM listener configured for HTTPS on the target.
+ *
  *
  * Communication protocol are:
  *      - WinRM
@@ -33,13 +35,13 @@ const instance = protocol.toLowerCase() === "ssh" ? new SSHHandler() : new WinRM
 const config = {
     "username": D.device.username(),
     "password": D.device.password(),
-    // WinRM transport options:
-    port: 5985,                // 5985 = HTTP, 5986 = HTTPS
-    scheme: "http",            // "http" | "https"
-    skipVerify: true,          // when scheme="https", skip TLS cert verification
-    auth: "auto",              // "basic" | "ntlm" | "auto" (inferred from username)
+    // WinRM transport options for HTTPS (port 5986). Adjust as needed:
+    port: 5986,                // 5986 = HTTPS (5985 for HTTP)
+    scheme: "https",           // "http" | "https"
+    skipVerify: true,          // set to false to enforce TLS certificate verification
+    // auth: "auto",           // "basic" | "ntlm" | "auto" (inferred from username)
     timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds (replaces legacy 'timeout' which was silently ignored)
+    timeoutSec: 30,            // per-command timeout in seconds
 };
 
 // Creation of custom driver table

--- a/examples/winrm/windows_updates_https.js
+++ b/examples/winrm/windows_updates_https.js
@@ -40,8 +40,7 @@ const config = {
     scheme: "https",           // "http" | "https"
     skipVerify: true,          // set to false to enforce TLS certificate verification
     // auth: "auto",           // "basic" | "ntlm" | "auto" (inferred from username)
-    timeout: 30000,             // SSH per-command timeout (ms); ignored by WinRM
-    timeoutSec: 30,            // per-command timeout in seconds
+    timeout: 30000,            // per-command timeout in milliseconds
 };
 
 // Creation of custom driver table

--- a/examples/winrm/windows_updates_https.json
+++ b/examples/winrm/windows_updates_https.json
@@ -1,0 +1,47 @@
+{
+    "logo": "windows.svg",
+    "version": "1.1.1",
+    "name": "Windows Updates (HTTPS)",
+    "description": "Collect data on missing updates for a windows host (over WinRM HTTPS on port 5986).",
+    "category": "Software Integration",
+    "requirements": {
+        "credentials": true,
+        "sandbox_version": "1.12",
+        "others": [
+            "Powershell Version 5.1.19041.2364",
+            "Privileged User Required",
+            "WinRM Enabled: To run the script using WinRM",
+            "SSH Enabled: To run the script using SSH",
+            "WinRM HTTPS listener enabled on the target (default port 5986)"
+        ]
+    },
+    "tags": [
+        "windows",
+        "update",
+        "software"
+    ],
+    "sample_period_s": 86400,
+    "has_actions": false,
+    "expected_variables": {
+        "independent": "[6]",
+        "table": "[0,999]"
+    },
+    "protocols": [
+        "WINRM",
+        "SSH"
+    ],
+    "tested_on": [
+        {
+            "name": "Microsoft Windows",
+            "version": "Server 2019"
+        }
+    ],
+    "parameters": [
+        {
+            "value_type": "STRING",
+            "name": "protocol",
+            "label": "Protocol",
+            "value": "WINRM"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

  Update WinRM example drivers in `examples/winrm/` to align with the refactored WinRM client in `remote_pawn_ng` (NEC-1583):

  1. Source code now supports HTTPS in addition to HTTP.
  2. WinRM timeout option renamed `timeoutSec` → `timeout` (milliseconds) to match the SSH convention. Internally, `remote_pawn_ng` converts ms → seconds when delegating to the Go backend.

  Companion PRs:
  - `remote_pawn_ng` PR (NEC-1583) — `cli.js`/`index.js`/legacy `Remote` changes, ms↔sec conversion, setting rename `winrm_command_timeout_sec` → `winrm_command_timeout_ms`
  - `custom_driver_api_doc` PR (NEC-1583) — regenerated `api/winrm.md` with `options.timeout` (ms)

  ## Changes

  ### Bugfix and rename: `timeout` (ms) is now the canonical WinRM timeout option

  - Previously, `timeout` (ms) was silently ignored by WinRM — only `timeoutSec` was wired through. WinRM now reads `timeout` (ms) like SSH.
  - All 25 retrofitted examples migrated to `timeout: 30000` (single key, used by both SSH and WinRM in dual-mode scripts).
  - `veeam_backup_sessions_monitoring.js` preserved at `timeout: 60000`.

  ### Expose WinRM transport options as active config keys

  All 25 existing examples declare the full set of WinRM transport options with their defaults:

  ```js
  port: 5985,            // 5985 = HTTP, 5986 = HTTPS
  scheme: "http",        // "http" | "https"
  skipVerify: true,      // when scheme="https", skip TLS cert verification
  auth: "auto",          // "basic" | "ntlm" | "auto" (inferred from username)
  timeout: 30000,        // per-command timeout in milliseconds
  ```

  Makes options discoverable and editable without breaking back-compat (defaults match prior behavior).

  New HTTPS variants (7 pairs of .js + .json)

  Preconfigured for WinRM over HTTPS on port 5986:

  - windows_cpu_usage_https
  - windows_cpu_memory_https
  - windows_logical_disks_https
  - windows_physical_disks_https
  - windows_os_general_info_https
  - windows_updates_https
  - windows_services_https

  Each variant:

  - Sets port: 5986, scheme: "https", skipVerify: true, timeout: 30000.
  - .json updated: name suffixed " (HTTPS)", description suffixed "(over WinRM HTTPS on port 5986)", version patch bumped, new requirement "WinRM HTTPS listener enabled on the target (default port 5986)".

  Compatibility

  - Requires the matching remote_pawn_ng change to land first (otherwise timeout is ignored by WinRM as before — defaults still apply, no crash).
  - timeoutSec is no longer accepted by remote_pawn_ng. Any external driver still passing it must migrate to timeout (ms).