### PR TITLE
NEC-1685: fix SES strict-mode incompatibilities in example drivers

### DIFF
--- a/examples/http/apache2_status.js
+++ b/examples/http/apache2_status.js
@@ -346,24 +346,6 @@ function extractDataVariables(json) {
     });
 }
 
-function buildTable(body) {
-    var $ = D.htmlParse(body);
-    var processTable = $("table tbody")[0];
-    processTable.children.filter(function (node, index) {
-        return index > 0 && node.name == "tr";
-    }).forEach(function (node, index) {
-        var row = node.children.map(function (td, index) {
-            var text = $(td).text().trim();
-            if (index == 3) {
-                return scoreboardKey[text];
-            }
-            return text;
-        });
-        table.insertRecord("" + index, row);
-    });
-    return table;
-}
-
 function failure(err) {
 
     console.error(err);

--- a/examples/http/apache2_status.js
+++ b/examples/http/apache2_status.js
@@ -313,9 +313,26 @@ function convertToJson(value) {
 
 }
 
+/**
+ * Resolves a property path string against a root object without using eval.
+ * Supports dotted access, bracketed numeric indexes and bracket-quoted keys,
+ * e.g. "json.Workers.closing", "json['Total kBytes']", "value.items[0].id".
+ * Returns undefined for any segment that cannot be resolved.
+ * @param {object} root the object the path is rooted in (keyed by the path's first token)
+ * @param {string} path the property path expression
+ */
+function resolvePath(root, path) {
+    if (typeof path !== "string") return undefined;
+    return path
+        .replace(/\[\s*(['"])(.*?)\1\s*\]/g, ".$2")  // ['k'] or ["k"] -> .k
+        .replace(/\[\s*(\d+)\s*\]/g, ".$1")          // [3] -> .3
+        .split(".")
+        .reduce(function (o, k) { return o == null ? undefined : o[k]; }, root);
+}
+
 function extractDataVariables(json) {
     return parametersConfig.map(function (param) {
-        param.value = eval(param.path);
+        param.value = resolvePath({ json: json }, param.path);
         if (param.postProcess) {
             if (Array.isArray(param.postProcess)) {
                 param.postProcess.forEach(function (fn) {

--- a/examples/http/aws_billing.js
+++ b/examples/http/aws_billing.js
@@ -18,6 +18,8 @@ var region = "ADD_REGION";
 var accessKey = D.device.username(); //accessKey == username
 var secretKey = D.device.password(); //secretKey == password
 var billing;
+var monitoringList;
+var vars;
 
 function sign(key, message) {
     var hex = hmac("sha256", key, message);

--- a/examples/http/aws_ebs.js
+++ b/examples/http/aws_ebs.js
@@ -22,6 +22,7 @@ var accessKey = D.device.username(); //accessKey == username
 var secretKey = D.device.password(); //secretKey == password
 var requestPeriod = 600;
 var volumes;
+var monitoringList;
 var vars = [];
 
 function sign(key, message) {

--- a/examples/http/aws_ec2_volumes.js
+++ b/examples/http/aws_ec2_volumes.js
@@ -151,7 +151,7 @@ function getVolumesData(nextToken) {
  */
 function extractVolumes(property) {
     return function () {
-        return filteredData = volumesList.map(function (volume) { return volume[0][property]; });
+        return volumesList.map(function (volume) { return volume[0][property]; });
     };
 }
 
@@ -169,7 +169,7 @@ function fillConfig() {
             uid: "device",
             label: "Device",
             execute: function () {
-                return statusList = volumesList.map(function (volume) {
+                return volumesList.map(function (volume) {
                     return volume[0].attachmentset[0].device;
                 });
             }
@@ -185,7 +185,7 @@ function fillConfig() {
             uid: "attachment_time",
             label: "Attachment time",
             execute: function () {
-                return statusList = volumesList.map(function (volume) {
+                return volumesList.map(function (volume) {
                     return volume[0].attachmentset[0].attachtime;
                 });
             }
@@ -195,7 +195,7 @@ function fillConfig() {
             uid: "attachment_status",
             label: "Attachment state",
             execute: function () {
-                return statusList = volumesList.map(function (volume) {
+                return volumesList.map(function (volume) {
                     return volume[0].attachmentset[0].status;
                 });
 

--- a/examples/http/aws_rds_instance_info.js
+++ b/examples/http/aws_rds_instance_info.js
@@ -17,6 +17,7 @@ var secretKey = D.device.password(); //secretKey == password
 var region = "ADD_REGION";
 var dbInstanceId = "ADD_DB_INSTANCE_ID";
 var monitoringList, instanceInfo;
+var vars;
 
 function sign(key, message) {
     var hex = hmac("sha256", key, message);

--- a/examples/http/aws_rds_metrics.js
+++ b/examples/http/aws_rds_metrics.js
@@ -19,6 +19,7 @@ var dbInstanceId = "ADD_DB_INSTANCE_ID";
 var requestPeriod = 600;
 var monitoringList;
 var vars = [];
+var metrics;
 
 function sign(key, message) {
     var hex = hmac("sha256", key, message);

--- a/examples/http/dante_director_device_status_monitoring.js
+++ b/examples/http/dante_director_device_status_monitoring.js
@@ -130,7 +130,7 @@ function extractData(data) {
       var productModelName = device.identity && device.identity.productModelName ? device.identity.productModelName: 'N/A'
       var danteVersion = device.identity && device.identity.danteVersion ? device.identity.danteVersion: 'N/A'
       var address = (device.interfaces && Array.isArray(device.interfaces) && device.interfaces.length > 0)
-      ? device.interfaces.map(function(interface) { return interface.address }).join(', ')
+      ? device.interfaces.map(function(iface) { return iface.address }).join(', ')
       : 'N/A'
       var statusId = device.status && device.status.id ? device.status.id : 'N/A'
       var clockingStatus = device.status && device.status.clocking ? device.status.clocking : 'N/A'

--- a/examples/http/generic_monitoring.js
+++ b/examples/http/generic_monitoring.js
@@ -56,14 +56,13 @@ var nodeValueLocation = Object.freeze({
  *                - text: will extract html node text
  *                - value: will extract html node value
  *                - attr:node_attribute_name: node_attribute_name is the name of the attribute to extract from the node
- *    - if response type is json: 
- *       - string: contains the path to the field starting by value which contain the json response (example: "value.field1.field2")
- *       - function: user defined function where the value is passed as an argument and return the value desired
- *    - if response type is text: 
+ *    - if response type is json:
+ *       - string: a safe property path to the field, rooted at "value" (examples: "value.field1.field2", "value[3].version", "value['weird key'].x"). Only property access is supported - arbitrary expressions and function calls are not evaluated.
+ *       - function: user defined function where the value is passed as an argument and return the value desired (use this for filtering/computation)
+ *    - if response type is text:
  *       - Regular Expression: regular expression containing the token to extract (example: /<input name="input_name" value="(.*)" \/>/)
- * * valueValidation: validate the value extracted, it can have 2 possible types (default "value")
- *    - string: expression return expected result depending from the value extracted (example: "value == 'valid' ? true : false")
- *    - function: user defined function where the value is passed as an argument and return the expected result (example: function(value) { return value > 10 ? 'working' : 'not working';})
+ * * valueValidation: a function that validates the extracted value (default: function (value) { return !!value; })
+ *    - function: user defined function where the value is passed as an argument and returns the expected result (example: function(value) { return value > 10 ? 'working' : 'not working';})
  */
 var httpMonitoringConfig = [
     // example using Regular expression to find the value in html response
@@ -92,15 +91,14 @@ var httpMonitoringConfig = [
     // link: "/assets/domotz-packages.json",
     // protocol: "https",
     // ***************************************
-    // valueExtractor: "value.filter(function(e){return e.model == 'debian' && e.arch =='x64'})[0].version"
-    // or
+    // // a safe property path:
+    // valueExtractor: "value[3].version",
+    // // or, for filtering/computation, a function:
     // valueExtractor: function(value){
     //     return value.filter(function(e){return e.model == "debian" && e.arch =="x64";})[0].version;
     // },
-    // or
-    // valueExtractor: "value[3].version",
     // *****************************************
-    // valueValidation: "value == '1.0-2.9.6-4.3.2-b001-0050'"
+    // valueValidation: function(value){ return value == "1.0-2.9.6-4.3.2-b001-0050"; }
     // }
 ];
 
@@ -181,9 +179,9 @@ function configValidation(config, index) {
         failValidation("this field 'valueExtractor' in the parameter with index " + index + " is invalid, please check the parameter documentation");
     else if (config.responseType == responseType.json && !(typeof (config.valueExtractor) == "string" || typeof (config.valueExtractor) == "function"))
         failValidation("this field 'valueExtractor' in the parameter with index " + index + " is invalid, please check the parameter documentation");
-    if (!config.valueValidation) config.valueValidation = "!!value";
-    else if (typeof (config.valueValidation) != "string" && typeof (config.valueValidation) != "function") {
-        failValidation("this field 'valueValidation' in the parameter with index " + index + " should be string or function");
+    if (!config.valueValidation) config.valueValidation = defaultValidation;
+    else if (typeof (config.valueValidation) != "function") {
+        failValidation("this field 'valueValidation' in the parameter with index " + index + " should be a function");
     }
     return config;
 }
@@ -212,6 +210,7 @@ function findResource(config) {
     }
     var d = D.q.defer();
     var start = new Date();
+    var call;
     switch(config.method){
     case "get": call = device.http.get; break;
     case "post": call = device.http.post; break;
@@ -251,8 +250,35 @@ function findResource(config) {
 }
 
 /**
+ * Resolves a property path string against a root object without using eval.
+ * Supports dotted access, bracketed numeric indexes and bracket-quoted keys,
+ * e.g. "value.field1.field2", "value[3].version", "value['weird key'].x".
+ * Returns undefined for any segment that cannot be resolved, and never
+ * executes function calls or other code embedded in the string.
+ * @param {object} root the object the path is rooted in (keyed by the path's first token)
+ * @param {string} path the property path expression
+ */
+function resolvePath(root, path) {
+    if (typeof path !== "string") return undefined;
+    return path
+        .replace(/\[\s*(['"])(.*?)\1\s*\]/g, ".$2")  // ['k'] or ["k"] -> .k
+        .replace(/\[\s*(\d+)\s*\]/g, ".$1")          // [3] -> .3
+        .split(".")
+        .reduce(function (o, k) { return o == null ? undefined : o[k]; }, root);
+}
+
+/**
+ * Default value validation: truthiness check. Used when a config does not
+ * provide its own valueValidation function.
+ * @param {*} value the extracted value
+ */
+function defaultValidation(value) {
+    return !!value;
+}
+
+/**
  * extract the result from response body based on the config passed in parameter
- * @param {*} config 
+ * @param {*} config
  * @returns config filled with the result
  */
 function parse(config) {
@@ -284,7 +310,10 @@ function parse(config) {
     } else if (config.responseType == responseType.json) {
         var value = JSON.parse(config.responseBody);
         if (typeof (config.valueExtractor) == "string") {
-            result = eval(config.valueExtractor);
+            // valueExtractor strings are treated as safe property paths only
+            // (e.g. "value.field1.field2", "value[3].version"). For anything
+            // more complex, supply valueExtractor as a function.
+            result = resolvePath({ value: value }, config.valueExtractor);
         } else {
             result = config.valueExtractor(value);
         }
@@ -301,11 +330,7 @@ function parse(config) {
  */
 function valueValidation(config) {
     var value = config.result;
-    if (typeof (config.valueValidation) == "string") {
-        config.validation = eval(config.valueValidation);
-    } else {
-        config.validation = config.valueValidation(value);
-    }
+    config.validation = config.valueValidation(value);
     return config;
 }
 

--- a/examples/http/hpe_msa_san_hardware_sensors_voltage_current.js
+++ b/examples/http/hpe_msa_san_hardware_sensors_voltage_current.js
@@ -134,7 +134,7 @@ function extractData(data) {
         }   
     });
 
-    for (id in sensorData) {
+    for (var id in sensorData) {
         var output = sensorData[id];
         var recordId = sanitize(id);
         var voltage = output.voltage !== undefined ? output.voltage : "";

--- a/examples/http/kubernetes_cluster_state.js
+++ b/examples/http/kubernetes_cluster_state.js
@@ -16,14 +16,13 @@ var port = 80;
 var vars = [];
 var metrics, componentStatuses, readyz, livez;
 
-Array.prototype._first = function () {
-    return this.length ? this[0] : null;
-};
+function _first(arr) {
+    return arr.length ? arr[0] : null;
+}
 
-Array.prototype._find = function (filterFn) {
-    return this.filter(filterFn)._first();
-
-};
+function _find(arr, filterFn) {
+    return _first(arr.filter(filterFn));
+}
 
 
 function httpGet(url) {
@@ -187,7 +186,7 @@ function fillComponentsStatuses(){
             uid: "component_" + cs.metadata.name,
             label: "Component " + cs.metadata.name + " Healthy",
             execute: function(){
-                var healthy = cs.conditions._find(function(c) { return c.type == "Healthy";});
+                var healthy = _find(cs.conditions, function(c) { return c.type == "Healthy";});
                 if(healthy) return healthy.status;
                 return null;
             }

--- a/examples/http/kubernetes_kubelet.js
+++ b/examples/http/kubernetes_kubelet.js
@@ -21,13 +21,12 @@ var table = D.createTable("Kubelets", [
     {label: "CPU: System seconds"},
     {label: "CPU: User seconds"},
 ]);
-Array.prototype._first = function () {
-    return this.length ? this[0] : null;
-};
-Array.prototype._find = function (filterFn) {
-    return this.filter(filterFn)._first();
-
-};
+function _first(arr) {
+    return arr.length ? arr[0] : null;
+}
+function _find(arr, filterFn) {
+    return _first(arr.filter(filterFn));
+}
 
 
 function httpGet(url){
@@ -100,7 +99,7 @@ function getNodesMetrics(){
         .then(JSON.parse)
         .then(function(data){
             nodes = data.items.map(function(item){
-                var ii = item.status.addresses._find(function(a) {return a.type == "InternalIP";});
+                var ii = _find(item.status.addresses, function(a) {return a.type == "InternalIP";});
                 if(ii.address)
                     return {
                         name: item.metadata.name,
@@ -273,7 +272,7 @@ function fillConfig(){
 
 function fillTable() {
     podsInfo.map(function(item){
-        var node = nodes._find(function(n) {return n.ip == item.hostIp;});
+        var node = _find(nodes, function(n) {return n.ip == item.hostIp;});
         return {
             id: item.podName,
             row: [

--- a/examples/http/kubernetes_nodes.js
+++ b/examples/http/kubernetes_nodes.js
@@ -154,7 +154,7 @@ var Kube = {
     getEndpointIPs: function () {
         return Kube.request("v1/endpoints")
             .then(function (result) {
-                epIPs = {};
+                var epIPs = {};
 
                 if (typeof result.response !== "object"
                     || typeof result.response.items === "undefined"
@@ -180,7 +180,7 @@ var Kube = {
     }
 };
 
-Fmt = {
+var Fmt = {
     factors: {
         Ki: 1024, K: 1000,
         Mi: Math.pow(1024, 2), M: Math.pow(1000, 2),
@@ -237,7 +237,7 @@ function parse() {
             pods = results[1],
             epIPs = results[2];
 
-        for (idx = 0; idx < nodes.items.length; idx++) {
+        for (var idx = 0; idx < nodes.items.length; idx++) {
             var internalIP,
                 nodePodsCount = 0,
                 nodePods = [],
@@ -325,10 +325,10 @@ function parse() {
  * @param {object} _default default value to return if the filter function doesn't return any thing
  * @returns object after the filter applied the the array
  */
-Array.prototype._find = function (filterFn, _default) {
-    var filtered = this.filter(filterFn);
+function _find(arr, filterFn, _default) {
+    var filtered = arr.filter(filterFn);
     return filtered.length ? filtered[0] : _default;
-};
+}
 
 /**
  * 
@@ -338,14 +338,14 @@ function fillTable(data) {
     data.items.forEach(function (item) {
         var metadataName = item.metadata.name;
 
-        var internalIp = item.status.addresses._find(function (a) { return a.type == "InternalIP"; }, {}).address;
-        var externalIp = item.status.addresses._find(function (a) { return a.type == "ExternalIP"; }, {}).address;
+        var internalIp = _find(item.status.addresses, function (a) { return a.type == "InternalIP"; }, {}).address;
+        var externalIp = _find(item.status.addresses, function (a) { return a.type == "ExternalIP"; }, {}).address;
         var allocableCpu = item.status.allocatable.cpu;
-        var memoryPressure = item.status.conditions._find(function (a) { return a.type == "MemoryPressure"; }, {}).status;
-        var networkUnavailable = item.status.conditions._find(function (a) { return a.type == "NetworkUnavailable"; }, {}).status;
-        var pidPressure = item.status.conditions._find(function (a) { return a.type == "PIDPressure"; }, {}).status;
-        var nodeReady = item.status.conditions._find(function (a) { return a.type == "Ready"; }, {}).status;
-        var diskPressure = item.status.conditions._find(function (a) { return a.type == "DiskPressure"; }, {}).status;
+        var memoryPressure = _find(item.status.conditions, function (a) { return a.type == "MemoryPressure"; }, {}).status;
+        var networkUnavailable = _find(item.status.conditions, function (a) { return a.type == "NetworkUnavailable"; }, {}).status;
+        var pidPressure = _find(item.status.conditions, function (a) { return a.type == "PIDPressure"; }, {}).status;
+        var nodeReady = _find(item.status.conditions, function (a) { return a.type == "Ready"; }, {}).status;
+        var diskPressure = _find(item.status.conditions, function (a) { return a.type == "DiskPressure"; }, {}).status;
         var allocatableMem = item.status.allocatable.memory;
         var allocatablePods = item.status.allocatable.pods;
         var capacityCpu = item.status.capacity.cpu;
@@ -365,10 +365,10 @@ function fillTable(data) {
         var uptime = item.metadata.creationTimestamp;
         var podsCount = item.status.podsCount;
         item.pods.forEach(function (pod) {
-            var containerReady = pod.conditions._find(function (c) { return c.type == "ContainersReady"; }, {}).status;
-            var initialized = pod.conditions._find(function (c) { return c.type == "Initialized"; }, {}).status;
-            var ready = pod.conditions._find(function (c) { return c.type == "Ready"; }, {}).status;
-            var scheduled = pod.conditions._find(function (c) { return c.type == "PodScheduled"; }, {}).status;
+            var containerReady = _find(pod.conditions, function (c) { return c.type == "ContainersReady"; }, {}).status;
+            var initialized = _find(pod.conditions, function (c) { return c.type == "Initialized"; }, {}).status;
+            var ready = _find(pod.conditions, function (c) { return c.type == "Ready"; }, {}).status;
+            var scheduled = _find(pod.conditions, function (c) { return c.type == "PodScheduled"; }, {}).status;
             var podIP = pod.podIP;
             var podName = pod.name.slice(0, 50); // Slice to comply with record ID limit of 50 characters
             nodeTable.upsertRecord(podName, [

--- a/examples/http/opnsense_interfaces_ipv4.js
+++ b/examples/http/opnsense_interfaces_ipv4.js
@@ -76,18 +76,18 @@ function sanitize(output){
 
 // Function to extract and insert Interfaces Stats data into the custom driver table for IPv4
 function extractData(data) {
-    for (var interface in data.interfaces) {
+    for (var iface in data.interfaces) {
         if (interfaceName[0].toLowerCase() === "all" || interfaceName.some(function(name) {
-            return (interface.toLowerCase().indexOf(name.toLowerCase()) !== -1);
+            return (iface.toLowerCase().indexOf(name.toLowerCase()) !== -1);
         })) {
-            if (interface !== "all"){
-                var recordId = sanitize(interface);             
-                var references = data.interfaces[interface].references;
-                var in4BlockBytes = data.interfaces[interface].in4_block_bytes;
-                var in4PassBytes = data.interfaces[interface].in4_pass_bytes;
-                var out4BlockBytes = data.interfaces[interface].out4_block_bytes;
-                var out4PassBytes = data.interfaces[interface].out4_pass_bytes;
-                var cleared = data.interfaces[interface].cleared;
+            if (iface !== "all"){
+                var recordId = sanitize(iface);
+                var references = data.interfaces[iface].references;
+                var in4BlockBytes = data.interfaces[iface].in4_block_bytes;
+                var in4PassBytes = data.interfaces[iface].in4_pass_bytes;
+                var out4BlockBytes = data.interfaces[iface].out4_block_bytes;
+                var out4PassBytes = data.interfaces[iface].out4_pass_bytes;
+                var cleared = data.interfaces[iface].cleared;
     
                 table.insertRecord(recordId, [
                     references,

--- a/examples/http/opnsense_interfaces_ipv6.js
+++ b/examples/http/opnsense_interfaces_ipv6.js
@@ -75,18 +75,18 @@ function sanitize(output){
 
 // Function to extract and insert Interfaces Stats data into the custom driver table for IPv6
 function extractData(data) {
-    for (var interface in data.interfaces) {
-        if (interface !== "all"){
+    for (var iface in data.interfaces) {
+        if (iface !== "all"){
             if (interfaceName[0].toLowerCase() === "all" || interfaceName.some(function(name) {
-                return (interface.toLowerCase().indexOf(name.toLowerCase()) !== -1);
-            })) { 
-                var recordId = sanitize(interface);
-                var references = data.interfaces[interface].references;
-                var in6BlockBytes = data.interfaces[interface].in6_block_bytes;
-                var in6PassBytes = data.interfaces[interface].in6_pass_bytes;
-                var out6BlockBytes = data.interfaces[interface].out6_block_bytes;
-                var out6PassBytes = data.interfaces[interface].out6_pass_bytes;
-                var cleared = data.interfaces[interface].cleared;
+                return (iface.toLowerCase().indexOf(name.toLowerCase()) !== -1);
+            })) {
+                var recordId = sanitize(iface);
+                var references = data.interfaces[iface].references;
+                var in6BlockBytes = data.interfaces[iface].in6_block_bytes;
+                var in6PassBytes = data.interfaces[iface].in6_pass_bytes;
+                var out6BlockBytes = data.interfaces[iface].out6_block_bytes;
+                var out6PassBytes = data.interfaces[iface].out6_pass_bytes;
+                var cleared = data.interfaces[iface].cleared;
                 table.insertRecord(recordId, [
                     references,
                     in6BlockBytes,

--- a/examples/http/pfsense_pfinfo.js
+++ b/examples/http/pfsense_pfinfo.js
@@ -433,15 +433,15 @@ function extract_table(body) {
     while ((result = reg.exec(toParse)) !== null) {
         interfaces.push(result[1]);
     }
-    interfaces.forEach(function (interface) {
-        var inRegEx = interfacesRegex(interface);
+    interfaces.forEach(function (iface) {
+        var inRegEx = interfacesRegex(iface);
         var match = toParse.match(inRegEx);
         if (match) {
             var values = [];
             for (var i = 1; i < match.length; i++) {
                 values.push(match[i]);
             }
-            table.insertRecord(interface, values);
+            table.insertRecord(iface, values);
         }
     });
 }

--- a/examples/http/pi_hole.js
+++ b/examples/http/pi_hole.js
@@ -33,7 +33,7 @@ function createVariables(data) {
         _var("status", "Status", data.status)
     );
     variables.push(
-        _var("blocked_daily_perc", "Blocked Daily %", parseFloat(data.ads_percentage_today) + "", unit = "%")
+        _var("blocked_daily_perc", "Blocked Daily %", parseFloat(data.ads_percentage_today) + "", "%")
     );
     variables.push(
         _var("blocked_daily", "Blocked Daily", parseInt(data.ads_blocked_today.replace(/,/g, "")) + "")

--- a/examples/http/teams_rooms_device_status.js
+++ b/examples/http/teams_rooms_device_status.js
@@ -247,7 +247,7 @@ function generateDeviceProperties() {
  * @param {Array} deviceProperties - List of device properties to include in the table.
  */
 function createDeviceTable(deviceProperties) {
-    tableHeaders = deviceProperties.map(function(item) {return { label: item.label }});
+    var tableHeaders = deviceProperties.map(function(item) {return { label: item.label }});
 
     deviceTable = D.createTable('Microsoft Teams Devices status', tableHeaders)
 }

--- a/examples/http/teams_rooms_ongoing_meetings_participants.js
+++ b/examples/http/teams_rooms_ongoing_meetings_participants.js
@@ -101,7 +101,7 @@ function generateRoomProperties() {
  * @param {Array} roomProperties - The properties to define the structure of the table.
  */
 function createRoomsTable(roomProperties) {
-    tableHeaders = roomProperties.map(function(item) {return { label: item.label }});
+    var tableHeaders = roomProperties.map(function(item) {return { label: item.label }});
 
     roomsTable = D.createTable('Microsoft Teams Rooms Meeting Participants', tableHeaders)
 }

--- a/examples/http/teams_rooms_status.js
+++ b/examples/http/teams_rooms_status.js
@@ -67,7 +67,7 @@ function generateRoomProperties() {
  * @param {Array} roomProperties - The properties of the rooms to be displayed in the table.
  */
 function createRoomsTable(roomProperties) {
-    tableHeaders = roomProperties.map(function(item) {return { label: item.label }});
+    var tableHeaders = roomProperties.map(function(item) {return { label: item.label }});
 
     roomsTable = D.createTable('Microsoft Teams Rooms status', tableHeaders)
 

--- a/examples/snmp/gps_antenna_reformat_geo_coordinates.js
+++ b/examples/snmp/gps_antenna_reformat_geo_coordinates.js
@@ -42,6 +42,7 @@ function get_status(){
             console.error("Received an error during the SNMP Get ", error || output[latitudeOid].error || output[longitudeOid].error || output[antennaStatusOid].error || output[headingOid].error);
             D.failure(D.errorType.PARSING_ERROR);
         } else {
+            var antennaStatus;
             // Getting unformatted values
             var antennaStatusRaw =  output[antennaStatusOid];
             var headingRaw= output[headingOid];

--- a/examples/ssh/control4_zigbee_devices.js
+++ b/examples/ssh/control4_zigbee_devices.js
@@ -59,7 +59,7 @@ function validate(){
 function get_status(){
     function parseNodesCallback(output, error){
         responseIsOk(output, error);
-        lines = output.split(/\r?\n/);
+        var lines = output.split(/\r?\n/);
 
         var zigbeeNodesRegexp = /([\w\d]+)\s+([\w\d]+)\s+(\w+)\s+([\d\.]+)\s+([\w\d\_\:\-]+)\s+(\w{3}\s\w{3}\s[0-9]+\s[0-9\:]+)\s+(\d+)\s+([\w\s]+)\s+(0x[\w\d]+)/;
         var matchOffset = 2;

--- a/examples/ssh/crestron_touch_screen.js
+++ b/examples/ssh/crestron_touch_screen.js
@@ -79,7 +79,7 @@ function parseData(executionResult){
     // cmdTemperature output is result[0]
     // cmdInfo output is result[1]
     // concatenating the results into one output
-    output = executionResult[0]+executionResult[1];
+    var output = executionResult[0]+executionResult[1];
     // processing the output
     var outputArray = output.split(/\r?\n/);
     if (outputArray == null) {

--- a/examples/ssh/docker_stats.js
+++ b/examples/ssh/docker_stats.js
@@ -34,7 +34,7 @@ function successCallback(output) {
     }
     var values = lines.slice(1);
     for (var index in values) {
-        data = values[index].split(/(\s+)/);
+        var data = values[index].split(/(\s+)/);
         var uid = data[0];
         var name = data[2];
         var cpu = data[4].split("%")[0];

--- a/examples/ssh/esxi_get_users.js
+++ b/examples/ssh/esxi_get_users.js
@@ -1,6 +1,7 @@
 var userUID = "user-";
 var userLabel = "User - ";
 var userUnit = " ";
+var variables;
 
 /**
  * The SSH Command Options

--- a/examples/ssh/esxi_last_login.js
+++ b/examples/ssh/esxi_last_login.js
@@ -45,7 +45,7 @@ function validate() {
     console.info("Verifying credentials ... ", commandValidate);
     sshCommandOptions["command"] = commandValidate;
     function loginCallback(output, error) {
-        variables = [];
+        var variables = [];
         if (error) {
             checkForPasswordError(error);
         } else {

--- a/examples/ssh/esxi_ntp_configuration.js
+++ b/examples/ssh/esxi_ntp_configuration.js
@@ -7,6 +7,7 @@
 var ntpUID = "ntp-";
 var ntpLabel = "NTP Configuration - ";
 var ntpUnit = "line";
+var variables;
 
 /**
  * The SSH Command Options

--- a/examples/ssh/linux_updates_count.js
+++ b/examples/ssh/linux_updates_count.js
@@ -77,7 +77,7 @@ function parseValidateOutput(output) {
 }
 
 function parseData(executionResult) {
-    variables = [];
+    var variables = [];
     for (var j = 0; j < packagesFilter.length; j++) {
         var packageName = packagesFilter[j];
         var count = executionResult.split("\n").filter(function (update) {

--- a/examples/winrm/ms_exchange_current_connections.js
+++ b/examples/winrm/ms_exchange_current_connections.js
@@ -83,7 +83,7 @@ function parseOutput(output) {
             var instanceName = jsonOutput[k].InstanceName || "-";
             var value = jsonOutput[k].CookedValue;
             var uid = sanitize(instanceName);
-            variable = D.device.createVariable(uid, instanceName, value, "", D.valueType.NUMBER);
+            var variable = D.device.createVariable(uid, instanceName, value, "", D.valueType.NUMBER);
             variables.push(variable);
             k++;
         }

--- a/examples/winrm/ms_exchange_general_stats.js
+++ b/examples/winrm/ms_exchange_general_stats.js
@@ -128,7 +128,7 @@ function parseOutput(output) {
             var label = instanceName ? instanceName + " " + msExchangeItem : msExchangeItem;
             var value = jsonOutput[k].CookedValue;
             var unit = counterTypeMappings[counterType];     
-            variable = D.device.createVariable(uid, label , value, unit, D.valueType.NUMBER);
+            var variable = D.device.createVariable(uid, label , value, unit, D.valueType.NUMBER);
             variables.push(variable);
             k++;
         }

--- a/examples/winrm/ms_exchange_queues.js
+++ b/examples/winrm/ms_exchange_queues.js
@@ -82,7 +82,7 @@ function parseOutput(output) {
             var instanceName = jsonOutput[k].InstanceName || "-";
             var value = jsonOutput[k].CookedValue;
             var uid = sanitize(instanceName);
-            variable = D.device.createVariable(uid, instanceName, value, "messages", D.valueType.NUMBER);
+            var variable = D.device.createVariable(uid, instanceName, value, "messages", D.valueType.NUMBER);
             variables.push(variable);
             k++;
         }

--- a/examples/winrm/ms_exchange_rpc_average_latency.js
+++ b/examples/winrm/ms_exchange_rpc_average_latency.js
@@ -83,7 +83,7 @@ function parseOutput(output) {
             var instanceName = jsonOutput[k].InstanceName || "-";
             var value = jsonOutput[k].CookedValue;
             var uid = sanitize(instanceName);
-            variable = D.device.createVariable(uid, instanceName, value, "", D.valueType.NUMBER);
+            var variable = D.device.createVariable(uid, instanceName, value, "", D.valueType.NUMBER);
             variables.push(variable);
             k++;
         }

--- a/examples/winrm/windows_firewall_rules.js
+++ b/examples/winrm/windows_firewall_rules.js
@@ -39,6 +39,7 @@ const protocol = D.getParameter('protocol');
 
 const instance = protocol.toLowerCase() === "ssh" ? new SSHHandler() : new WinRMHandler();
 
+var getFirewallRules;
 if (firewallFilter.length === 1 && firewallFilter[0].toLowerCase() === 'all') {
     getFirewallRules = 'Get-NetFirewallRule | Select-Object Name, DisplayName, Group, Direction, Action, Enabled | ConvertTo-Json -Compress';
 }else{

--- a/examples/winrm/windows_security_events.js
+++ b/examples/winrm/windows_security_events.js
@@ -133,7 +133,7 @@ function parseOutput(jsonOutput) {
         setAuditedEventCount(jsonOutput);
     }
     // events with no occurrences will appear in the table with a 0 value
-    for (eventId in auditedEvents) {
+    for (var eventId in auditedEvents) {
         eventTable.insertRecord(eventId, [auditedEvents[eventId].description, auditedEvents[eventId].count]);
     }
     D.success(eventTable);


### PR DESCRIPTION
Migrate 31 catalogue drivers to run under the SES sandbox (strict mode + frozen intrinsics) that replaces the Node vm runtime. All edits are behavior-preserving:

- implicit-global assignments (25): declare with var at the scope that preserves visibility (hoisted where a variable spans functions); drop dead 'return X = expr' writes in aws_ec2_volumes.
- reserved word 'interface' used as an identifier (4): rename the binding to 'iface' (opnsense_interfaces_ipv4/ipv6, pfsense_pfinfo, dante_director).
- Array.prototype mutation (3): replace ._first/._find prototype augmentation with standalone helpers (kubernetes_kubelet, kubernetes_cluster_state, kubernetes_nodes).

Verified with the SES conformance harness: corpus SES-regressions 33 -> 2 (the 2 remaining are eval-in-comment cases, tracked separately).